### PR TITLE
Reload support for plugins

### DIFF
--- a/BlockTree/BlockCache.cpp
+++ b/BlockTree/BlockCache.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
 #include "BlockTree/BlockCache.hpp"
-#include "GraphObjects/GraphBlock.hpp"
 #include "HostExplorer/HostExplorerDock.hpp"
 #include "MainWindow/MainSplash.hpp"
 #include <Pothos/Remote.hpp>
@@ -54,7 +53,7 @@ BlockCache::BlockCache(QObject *parent, HostExplorerDock *hostExplorer):
     assert(_hostExplorerDock != nullptr);
     connect(_watcher, SIGNAL(resultReadyAt(int)), this, SLOT(handleWatcherDone(int)));
     connect(_watcher, SIGNAL(finished(void)), this, SLOT(handleWatcherFinished(void)));
-    connect(_hostExplorerDock, SIGNAL(hostUriListChanged(void)), this, SLOT(handleUpdate(void)));
+    connect(_hostExplorerDock, SIGNAL(hostUriListChanged(void)), this, SLOT(update(void)));
 }
 
 Poco::JSON::Object::Ptr BlockCache::getBlockDescFromPath(const std::string &path)
@@ -85,7 +84,13 @@ Poco::JSON::Object::Ptr BlockCache::getBlockDescFromPath(const std::string &path
     return Poco::JSON::Object::Ptr();
 }
 
-void BlockCache::handleUpdate(void)
+void BlockCache::clear(void)
+{
+    Poco::RWLock::ScopedWriteLock lock(_mapMutex);
+    _pathToBlockDesc.clear();
+}
+
+void BlockCache::update(void)
 {
     MainSplash::global()->postMessage(tr("Updating block cache..."));
 

--- a/BlockTree/BlockCache.hpp
+++ b/BlockTree/BlockCache.hpp
@@ -33,7 +33,8 @@ signals:
     void blockDescReady(void);
 
 public slots:
-    void handleUpdate(void);
+    void clear(void);
+    void update(void);
 
 private slots:
     void handleWatcherFinished(void);

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ This this the changelog file for the Pothos GUI toolkit.
 Release 0.4.0 (pending)
 ==========================
 
+- Added plugin reload feature without closing/reopening the GUI
 - Re-factor access between top level objects, cleanup indirection
 - Added icons for every scale type for the freedesktop.org install
 - Added editable dimension option to the DTypeChooser edit widget

--- a/EvalEngine/EvalEngine.cpp
+++ b/EvalEngine/EvalEngine.cpp
@@ -35,7 +35,7 @@ EvalEngine::EvalEngine(QObject *parent):
 
     connect(_monitorTimer, SIGNAL(timeout(void)), this, SLOT(handleMonitorTimeout(void)));
     connect(_impl, SIGNAL(monitorHeartBeat(void)), this, SLOT(handleEvalThreadHeartBeat(void)));
-    connect(_impl, SIGNAL(deactivateDesign(void)), this, SIGNAL(deactivateDesign(void)));
+    connect(_impl, SIGNAL(deactivateDesign(void)), parent, SLOT(handleEvalEngineDeactivate(void)));
 }
 
 EvalEngine::~EvalEngine(void)

--- a/EvalEngine/EvalEngine.hpp
+++ b/EvalEngine/EvalEngine.hpp
@@ -62,11 +62,6 @@ public slots:
     //! query the JSON stats for the active topology
     std::string getTopologyJSONStats(void);
 
-signals:
-
-    //! A failure occured, this is a notification to deactivate
-    void deactivateDesign(void);
-
 private slots:
     void handleAffinityZonesChanged(void);
     void handleEvalThreadHeartBeat(void);

--- a/EvalEngine/EvalEngineImpl.cpp
+++ b/EvalEngine/EvalEngineImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 Josh Blum
+// Copyright (c) 2014-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "EvalEngineImpl.hpp"
@@ -73,11 +73,13 @@ void EvalEngineImpl::submitActivateTopology(const bool enable)
     {
         _topologyEval.reset(new TopologyEval());
         _requireEval = true;
-        this->evaluate();
     }
 
     //if disabled, clear the current evaluator if present
     if (not enable) _topologyEval.reset();
+
+    //call into the conditional evaluation regardless
+    this->evaluate();
 }
 
 void EvalEngineImpl::submitBlock(const BlockInfo &info)

--- a/GraphEditor/GraphDraw.cpp
+++ b/GraphEditor/GraphDraw.cpp
@@ -58,7 +58,7 @@ GraphDraw::GraphDraw(QWidget *parent):
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)),
         this, SLOT(handleCustomContextMenuRequested(const QPoint &)));
     connect(this, SIGNAL(modifyProperties(QObject *)),
-        PropertiesPanelDock::global(), SLOT(handleGraphModifyProperties(QObject *)));
+        PropertiesPanelDock::global(), SLOT(launchEditor(QObject *)));
     connect(this->scene(), SIGNAL(selectionChanged(void)), this, SLOT(updateEnabledActions(void)));
 
     //debug view - connect and initialize

--- a/GraphEditor/GraphEditor.cpp
+++ b/GraphEditor/GraphEditor.cpp
@@ -44,7 +44,7 @@ GraphEditor::GraphEditor(QWidget *parent):
     _moveGraphObjectsMapper(new QSignalMapper(this)),
     _insertGraphWidgetsMapper(new QSignalMapper(this)),
     _stateManager(new GraphStateManager(this)),
-    _evalEngine(new EvalEngine(this)),
+    _evalEngine(nullptr),
     _isTopologyActive(false)
 {
     this->setDocumentMode(true);
@@ -94,21 +94,37 @@ GraphEditor::GraphEditor(QWidget *parent):
     connect(actions->decrementAction, SIGNAL(triggered(void)), this, SLOT(handleBlockDecrement(void)));
     connect(_moveGraphObjectsMapper, SIGNAL(mapped(int)), this, SLOT(handleMoveGraphObjects(int)));
     connect(_insertGraphWidgetsMapper, SIGNAL(mapped(QObject *)), this, SLOT(handleInsertGraphWidget(QObject *)));
-    connect(_evalEngine, SIGNAL(deactivateDesign(void)), this, SLOT(handleEvalEngineDeactivate(void)));
     connect(this, SIGNAL(newTitleSubtext(const QString &)), _parentTabWidget->parent(), SLOT(handleNewTitleSubtext(const QString &)));
 }
 
 GraphEditor::~GraphEditor(void)
 {
-    //cleanup all graph objects, blocks may hold widgets
-    for (auto obj : this->getGraphObjects()) delete obj;
-
     //stop the eval engine and its evaluator thread
-    delete _evalEngine;
+    this->stopEvaluation();
 
     //the actions dock owns state manager for display purposes,
     //so delete it here when the graph editor is actually done with it
     delete _stateManager;
+}
+
+void GraphEditor::stopEvaluation(void)
+{
+    delete _evalEngine;
+    _evalEngine = nullptr;
+}
+
+void GraphEditor::startEvaluation(void)
+{
+    //force all blocks to reload the block description
+    for (auto obj : this->getGraphObjects(GRAPH_BLOCK))
+    {
+        obj->deserialize(obj->serialize());
+    }
+
+    _evalEngine = new EvalEngine(this);
+    connect(_evalEngine, SIGNAL(deactivateDesign(void)), this, SLOT(handleEvalEngineDeactivate(void)));
+    _evalEngine->submitTopology(this->getGraphObjects());
+    _evalEngine->submitActivateTopology(_isTopologyActive);
 }
 
 QString GraphEditor::newId(const QString &hint, const QStringList &blacklist) const
@@ -796,6 +812,7 @@ void GraphEditor::handleReeval(void)
 {
     if (not this->isVisible()) return;
     auto draw = this->getCurrentGraphDraw();
+    if (_evalEngine == nullptr) return;
     _evalEngine->submitReeval(draw->getObjectsSelected(GRAPH_BLOCK));
 }
 
@@ -874,6 +891,7 @@ void GraphEditor::handleStateChange(const GraphState &state)
 void GraphEditor::handleToggleActivateTopology(const bool enable)
 {
     if (not this->isVisible()) return;
+    if (_evalEngine == nullptr) return;
     _evalEngine->submitActivateTopology(enable);
     _isTopologyActive = enable;
 }
@@ -930,14 +948,14 @@ void GraphEditor::handleBlockXcrement(const int adj)
 void GraphEditor::updateExecutionEngine(void)
 {
     this->deleteFlagged(); //scan+remove deleted before submit
+    if (_evalEngine == nullptr) return;
     _evalEngine->submitTopology(this->getGraphObjects());
 }
 
 void GraphEditor::handleEvalEngineDeactivate(void)
 {
-    auto actions = MainActions::global();
-    actions->activateTopologyAction->setChecked(false);
     _isTopologyActive = false;
+    this->updateEnabledActions();
 }
 
 void GraphEditor::save(void)
@@ -989,6 +1007,7 @@ void GraphEditor::load(void)
     _stateManager->saveCurrent();
     this->updateGraphEditorMenus();
     this->render();
+    this->startEvaluation();
 }
 
 void GraphEditor::render(void)

--- a/GraphEditor/GraphEditor.cpp
+++ b/GraphEditor/GraphEditor.cpp
@@ -44,7 +44,7 @@ GraphEditor::GraphEditor(QWidget *parent):
     _moveGraphObjectsMapper(new QSignalMapper(this)),
     _insertGraphWidgetsMapper(new QSignalMapper(this)),
     _stateManager(new GraphStateManager(this)),
-    _evalEngine(nullptr),
+    _evalEngine(new EvalEngine(this)),
     _isTopologyActive(false)
 {
     this->setDocumentMode(true);
@@ -113,7 +113,7 @@ void GraphEditor::stopEvaluation(void)
     _evalEngine = nullptr;
 }
 
-void GraphEditor::startEvaluation(void)
+void GraphEditor::restartEvaluation(void)
 {
     //force all blocks to reload the block description
     for (auto obj : this->getGraphObjects(GRAPH_BLOCK))
@@ -122,7 +122,6 @@ void GraphEditor::startEvaluation(void)
     }
 
     _evalEngine = new EvalEngine(this);
-    connect(_evalEngine, SIGNAL(deactivateDesign(void)), this, SLOT(handleEvalEngineDeactivate(void)));
     _evalEngine->submitTopology(this->getGraphObjects());
     _evalEngine->submitActivateTopology(_isTopologyActive);
 }
@@ -1007,7 +1006,6 @@ void GraphEditor::load(void)
     _stateManager->saveCurrent();
     this->updateGraphEditorMenus();
     this->render();
-    this->startEvaluation();
 }
 
 void GraphEditor::render(void)

--- a/GraphEditor/GraphEditor.hpp
+++ b/GraphEditor/GraphEditor.hpp
@@ -27,7 +27,7 @@ public:
     void stopEvaluation(void);
 
     //! Restore evaluator and from a plugin reload
-    void startEvaluation(void);
+    void restartEvaluation(void);
 
     void dumpState(std::ostream &os) const;
 

--- a/GraphEditor/GraphEditor.hpp
+++ b/GraphEditor/GraphEditor.hpp
@@ -23,6 +23,12 @@ public:
     GraphEditor(QWidget *parent);
     ~GraphEditor(void);
 
+    //! Stop the evaluator and for plugin reload
+    void stopEvaluation(void);
+
+    //! Restore evaluator and from a plugin reload
+    void startEvaluation(void);
+
     void dumpState(std::ostream &os) const;
 
     void loadState(std::istream &os);

--- a/GraphEditor/GraphEditorTabs.cpp
+++ b/GraphEditor/GraphEditorTabs.cpp
@@ -52,12 +52,6 @@ GraphEditor *GraphEditorTabs::getCurrentGraphEditor(void) const
     return this->getGraphEditor(this->currentIndex());
 }
 
-void GraphEditorTabs::handleInit(void)
-{
-    MainSplash::global()->postMessage(tr("Restoring graph editor..."));
-    this->loadState();
-}
-
 void GraphEditorTabs::handleNew(void)
 {
     auto editor = new GraphEditor(this);
@@ -256,6 +250,8 @@ void GraphEditorTabs::handleExit(QCloseEvent *event)
 
 void GraphEditorTabs::loadState(void)
 {
+    MainSplash::global()->postMessage(tr("Restoring graph editor..."));
+
     //load option topologies from file list
     auto settings = MainSettings::global();
     auto files = settings->value("GraphEditorTabs/files").toStringList();

--- a/GraphEditor/GraphEditorTabs.hpp
+++ b/GraphEditor/GraphEditorTabs.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 Josh Blum
+// Copyright (c) 2014-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -13,14 +13,15 @@ class GraphEditorTabs : public QTabWidget
 public:
     GraphEditorTabs(QWidget *parent);
 
-    void loadState(void);
-    void saveState(void);
-
     GraphEditor *getGraphEditor(const int index) const;
     GraphEditor *getCurrentGraphEditor(void) const;
 
+public slots:
+
+    void loadState(void);
+    void saveState(void);
+
 private slots:
-    void handleInit(void);
     void handleNew(void);
     void handleOpen(void);
     void handleOpen(const QString &filePath);

--- a/GraphObjects/GraphBlock.cpp
+++ b/GraphObjects/GraphBlock.cpp
@@ -842,13 +842,13 @@ Poco::JSON::Object::Ptr GraphBlock::serialize(void) const
         obj->set("activeEditTab", this->getActiveEditTab());
     }
 
-    Poco::JSON::Array jPropsObj;
+    Poco::JSON::Array::Ptr jPropsObj(new Poco::JSON::Array);
     for (const auto &propKey : this->getProperties())
     {
-        Poco::JSON::Object jPropObj;
-        jPropObj.set("key", propKey.toStdString());
-        jPropObj.set("value", this->getPropertyValue(propKey).toStdString());
-        jPropsObj.add(jPropObj);
+        Poco::JSON::Object::Ptr jPropObj(new Poco::JSON::Object);
+        jPropObj->set("key", propKey.toStdString());
+        jPropObj->set("value", this->getPropertyValue(propKey).toStdString());
+        jPropsObj->add(jPropObj);
     }
     obj->set("properties", jPropsObj);
 

--- a/GraphObjects/GraphBlockUpdate.cpp
+++ b/GraphObjects/GraphBlockUpdate.cpp
@@ -24,6 +24,9 @@ void GraphBlock::setBlockDesc(const Poco::JSON::Object::Ptr &blockDesc)
     }
     this->setTitle(QString::fromStdString(name));
 
+    //reload properties description, clear the old first
+    _properties.clear();
+
     //extract the params or properties from the description
     if (blockDesc->isArray("params")) for (const auto &paramObj : *blockDesc->getArray("params"))
     {

--- a/MainWindow/MainActions.cpp
+++ b/MainWindow/MainActions.cpp
@@ -32,7 +32,7 @@ MainActions::MainActions(QObject *parent):
     saveAllAction = new QAction(makeIconFromTheme("document-save-all"), tr("Save A&ll"), this);
     saveAllAction->setShortcut(QKeySequence("CTRL+SHIFT+A"));
 
-    reloadAction = new QAction(makeIconFromTheme("view-refresh"), tr("&Reload"), this);
+    reloadAction = new QAction(makeIconFromTheme("document-revert"), tr("&Reload"), this);
     QList<QKeySequence> reloadShortcuts;
     reloadShortcuts.push_back(QKeySequence::Refresh);
     reloadShortcuts.push_back(QKeySequence("CTRL+R"));
@@ -44,7 +44,6 @@ MainActions::MainActions(QObject *parent):
 
     exitAction = new QAction(makeIconFromTheme("application-exit"), tr("&Exit Pothos GUI"), this);
     exitAction->setShortcut(QKeySequence::Quit);
-    connect(exitAction, SIGNAL(triggered(void)), parent, SLOT(close(void)));
 
     undoAction = new QAction(makeIconFromTheme("edit-undo"), tr("&Undo"), this);
     undoAction->setShortcut(QKeySequence::Undo);
@@ -64,7 +63,7 @@ MainActions::MainActions(QObject *parent):
     disableAction->setStatusTip(tr("Disable selected graph objects"));
     disableAction->setShortcut(QKeySequence(Qt::Key_D));
 
-    reevalAction = new QAction(makeIconFromTheme("document-revert"), tr("Re-eval"), this);
+    reevalAction = new QAction(makeIconFromTheme("edit-clear-history"), tr("Re-eval"), this);
     reevalAction->setStatusTip(tr("Re-evaluate selected graph objects"));
     reevalAction->setShortcut(QKeySequence(Qt::Key_R));
 
@@ -146,15 +145,12 @@ MainActions::MainActions(QObject *parent):
 
     showAboutAction = new QAction(makeIconFromTheme("help-about"), tr("&About Pothos"), this);
     showAboutAction->setStatusTip(tr("Information about this version of Pothos"));
-    connect(showAboutAction, SIGNAL(triggered(void)), parent, SLOT(handleShowAbout(void)));
 
     showAboutQtAction = new QAction(makeIconFromTheme("help-about"), tr("About &Qt"), this);
     showAboutQtAction->setStatusTip(tr("Information about this version of QT"));
-    connect(showAboutQtAction, SIGNAL(triggered(void)), parent, SLOT(handleShowAboutQt(void)));
 
     showColorsDialogAction = new QAction(makeIconFromTheme("color-picker"), tr("&Colors Map"), this);
     showColorsDialogAction->setStatusTip(tr("Data type colors used for block properties and ports"));
-    connect(showColorsDialogAction, SIGNAL(triggered(void)), parent, SLOT(handleColorsDialogAction(void)));
 
     incrementAction = new QAction(makeIconFromTheme("list-add"), tr("Block &Increment"), this);
     incrementAction->setStatusTip(tr("Increment action on selected graph objects"));
@@ -168,5 +164,7 @@ MainActions::MainActions(QObject *parent):
     fullScreenViewAction->setCheckable(true);
     fullScreenViewAction->setStatusTip(tr("Maximize graph editor area, hide dock widgets"));
     fullScreenViewAction->setShortcut(QKeySequence(Qt::Key_F11));
-    connect(fullScreenViewAction, SIGNAL(toggled(bool)), parent, SLOT(handleFullScreenViewAction(bool)));
+
+    reloadPluginsAction = new QAction(makeIconFromTheme("view-refresh"), tr("Reload plugin registry"), this);
+    reloadPluginsAction->setStatusTip(tr("Stop evaluation, reload plugins, resume evaluation"));
 }

--- a/MainWindow/MainActions.hpp
+++ b/MainWindow/MainActions.hpp
@@ -66,4 +66,5 @@ public:
     QAction *incrementAction;
     QAction *decrementAction;
     QAction *fullScreenViewAction;
+    QAction *reloadPluginsAction;
 };

--- a/MainWindow/MainMenu.cpp
+++ b/MainWindow/MainMenu.cpp
@@ -71,6 +71,7 @@ MainMenu::MainMenu(QMainWindow *parent, MainActions *actions):
     executeMenu->addAction(actions->activateTopologyAction);
     executeMenu->addAction(actions->showRenderedGraphAction);
     executeMenu->addAction(actions->showTopologyStatsAction);
+    executeMenu->addAction(actions->reloadPluginsAction);
 
     viewMenu = parent->menuBar()->addMenu(tr("&View"));
     viewMenu->addAction(actions->zoomInAction);

--- a/MainWindow/MainToolBar.cpp
+++ b/MainWindow/MainToolBar.cpp
@@ -29,6 +29,7 @@ MainToolBar::MainToolBar(QWidget *parent, MainActions *actions):
     this->addSeparator();
 
     this->addAction(actions->activateTopologyAction);
+    this->addAction(actions->reloadPluginsAction);
     this->addSeparator();
 
     this->addAction(actions->cutAction);

--- a/MainWindow/MainWindow.cpp
+++ b/MainWindow/MainWindow.cpp
@@ -68,6 +68,13 @@ MainWindow::MainWindow(QWidget *parent):
     _splash->postMessage(tr("Creating menus..."));
     auto mainMenu = new MainMenu(this, _actions);
 
+    //connect actions to the main window
+    connect(_actions->exitAction, SIGNAL(triggered(void)), this, SLOT(close(void)));
+    connect(_actions->showAboutAction, SIGNAL(triggered(void)), this, SLOT(handleShowAbout(void)));
+    connect(_actions->showAboutQtAction, SIGNAL(triggered(void)), this, SLOT(handleShowAboutQt(void)));
+    connect(_actions->showColorsDialogAction, SIGNAL(triggered(void)), this, SLOT(handleColorsDialogAction(void)));
+    connect(_actions->fullScreenViewAction, SIGNAL(toggled(bool)), this, SLOT(handleFullScreenViewAction(bool)));
+
     //create message window dock
     _splash->postMessage(tr("Creating message window..."));
     auto messageWindowDock = new MessageWindowDock(this);

--- a/MainWindow/MainWindow.cpp
+++ b/MainWindow/MainWindow.cpp
@@ -249,7 +249,7 @@ void MainWindow::handleReloadPlugins(void)
     for (int i = 0; i < _editorTabs->count(); i++)
     {
         auto editor = dynamic_cast<GraphEditor *>(_editorTabs->widget(i));
-        if (editor != nullptr) editor->startEvaluation();
+        if (editor != nullptr) editor->restartEvaluation();
     }
 
     poco_information(Poco::Logger::get("PothosGui.MainWindow"), "Reload plugins complete");

--- a/MainWindow/MainWindow.hpp
+++ b/MainWindow/MainWindow.hpp
@@ -13,7 +13,9 @@ class QShowEvent;
 class MainSplash;
 class MainSettings;
 class MainActions;
+class BlockCache;
 class GraphEditorTabs;
+class PropertiesPanelDock;
 
 class MainWindow : public QMainWindow
 {
@@ -35,6 +37,7 @@ private slots:
     void handleShowAboutQt(void);
     void handleColorsDialogAction(void);
     void handleFullScreenViewAction(const bool);
+    void handleReloadPlugins(void);
 
 protected:
     void closeEvent(QCloseEvent *event);
@@ -46,7 +49,9 @@ private:
     MainSettings *_settings;
     MainActions *_actions;
     Pothos::RemoteServer _server;
+    BlockCache *_blockCache;
     GraphEditorTabs *_editorTabs;
+    PropertiesPanelDock *_propertiesPanel;
 
     //restoring from full screen
     std::map<QWidget *, bool> _widgetToOldVisibility;

--- a/MainWindow/MainWindow.hpp
+++ b/MainWindow/MainWindow.hpp
@@ -17,6 +17,11 @@ class BlockCache;
 class GraphEditorTabs;
 class PropertiesPanelDock;
 
+/*!
+ * The MainWindow is the entry point for the entire GUI application.
+ * It sets up the various top level dock widgets, editor tabs,
+ * creates main actions and menu items, and loads Pothos plugins.
+ */
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -55,4 +60,7 @@ private:
 
     //restoring from full screen
     std::map<QWidget *, bool> _widgetToOldVisibility;
+
+    //! Setup server for scratch process
+    void setupServer(void);
 };

--- a/PropertiesPanel/PropertiesPanelDock.cpp
+++ b/PropertiesPanel/PropertiesPanelDock.cpp
@@ -58,7 +58,7 @@ PropertiesPanelDock::PropertiesPanelDock(QWidget *parent):
     }
 }
 
-void PropertiesPanelDock::handleGraphModifyProperties(QObject *obj)
+void PropertiesPanelDock::launchEditor(QObject *obj)
 {
     //clear old panel
     if (_propertiesPanel)

--- a/PropertiesPanel/PropertiesPanelDock.hpp
+++ b/PropertiesPanel/PropertiesPanelDock.hpp
@@ -22,9 +22,12 @@ public:
 signals:
     void replacePanel(void);
 
-private slots:
+public slots:
 
-    void handleGraphModifyProperties(QObject *obj);
+    //! Load the editor based on the type of graph object
+    void launchEditor(QObject *obj);
+
+private slots:
 
     void handlePanelDestroyed(QObject *);
 


### PR DESCRIPTION
This implements live reloading of plugins issue #105. The reload is manual with a new reload button in the execute menu and toolbar. With this capability, and automatic reload could be created based on detecting directory changes. In this case automatic reloading would have to be an optional gui configuration in case it does not behave well.

**Notes:** Reloading is not possible for blocks in the current GUI process. This includes widget and plotter blocks as well as any blocks specifically assigned to the GUI affinity. The reason is that Qt does not support plugin unloading when it comes to the QMetaType stuff. Qt stores the original addresses of the registered types with no way to remove them on unload or update on reload. The result is a lot of segfaulting for Qwt based classes and any gui classes using invoke method or meta type. Relevant blog: http://blog.kadu.im/2014/11/qmetatype-in-plugins.html

