### PR TITLE
Export format to JSON topology

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ list(APPEND SOURCES
     GraphEditor/GraphState.cpp
     GraphEditor/GraphEditorTabs.cpp
     GraphEditor/GraphEditor.cpp
+    GraphEditor/GraphEditorExport.cpp
     GraphEditor/GraphEditorSerialization.cpp
     GraphEditor/GraphEditorDeserialization.cpp
     GraphEditor/GraphEditorRenderedDialog.cpp

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ This this the changelog file for the Pothos GUI toolkit.
 Release 0.4.0 (pending)
 ==========================
 
+- Added menu option to export design to JSON topology format
 - Added ColorPicker edit widget for parameter color selection
 - Integrate GraphWidget with optional save/restore state hooks
 - Added plugin reload feature without closing/reopening the GUI

--- a/GraphEditor/GraphEditor.cpp
+++ b/GraphEditor/GraphEditor.cpp
@@ -191,6 +191,7 @@ void GraphEditor::updateEnabledActions(void)
     actions->redoAction->setEnabled(_stateManager->isSubsequentAvailable());
     actions->saveAction->setEnabled(not _stateManager->isCurrentSaved());
     actions->reloadAction->setEnabled(not this->getCurrentFilePath().isEmpty());
+    actions->exportAction->setEnabled(not this->getCurrentFilePath().isEmpty());
     actions->activateTopologyAction->setChecked(_isTopologyActive);
 
     //can we paste something from the clipboard?
@@ -1020,6 +1021,12 @@ void GraphEditor::load(void)
     _stateManager->saveCurrent();
     this->updateGraphEditorMenus();
     this->render();
+}
+
+void GraphEditor::exportToJSONTopology(const QString &path)
+{
+    poco_information_f1(_logger, "Exporting %s", path.toStdString());
+    //TODO
 }
 
 void GraphEditor::render(void)

--- a/GraphEditor/GraphEditor.cpp
+++ b/GraphEditor/GraphEditor.cpp
@@ -1023,12 +1023,6 @@ void GraphEditor::load(void)
     this->render();
 }
 
-void GraphEditor::exportToJSONTopology(const QString &path)
-{
-    poco_information_f1(_logger, "Exporting %s", path.toStdString());
-    //TODO
-}
-
 void GraphEditor::render(void)
 {
     //generate a title

--- a/GraphEditor/GraphEditor.hpp
+++ b/GraphEditor/GraphEditor.hpp
@@ -52,6 +52,9 @@ public:
     //! Deserializes the editor from the file.
     void load(void);
 
+    //! Export the design to JSON topology format give the file path
+    void exportToJSONTopology(const QString &path);
+
     const QString &getCurrentFilePath(void) const
     {
         return _currentFilePath;

--- a/GraphEditor/GraphEditor.hpp
+++ b/GraphEditor/GraphEditor.hpp
@@ -53,7 +53,7 @@ public:
     void load(void);
 
     //! Export the design to JSON topology format give the file path
-    void exportToJSONTopology(const QString &path);
+    void exportToJSONTopology(const QString &fileName);
 
     const QString &getCurrentFilePath(void) const
     {

--- a/GraphEditor/GraphEditorExport.cpp
+++ b/GraphEditor/GraphEditorExport.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2016-2016 Josh Blum
+// SPDX-License-Identifier: BSL-1.0
+
+#include "GraphEditor/GraphEditor.hpp"
+#include "GraphObjects/GraphBlock.hpp"
+#include "GraphEditor/Constants.hpp"
+#include "EvalEngine/TopologyEval.hpp"
+#include <Poco/JSON/Array.h>
+#include <Poco/JSON/Object.h>
+#include <fstream>
+
+void GraphEditor::exportToJSONTopology(const QString &fileName)
+{
+    poco_information_f1(_logger, "Exporting %s", fileName.toStdString());
+    Poco::JSON::Object topObj;
+
+    //all graph objects excluding widgets which are not exported
+    //we will have to filter out graphical blocks as well
+    const auto graphObjects = this->getGraphObjects(~GRAPH_WIDGET);
+
+    //global variables
+    Poco::JSON::Array globals;
+    for (const auto &name : this->listGlobals())
+    {
+        const auto &value = this->getGlobalExpression(name);
+        Poco::JSON::Object globalObj;
+        globalObj.set("name", name.toStdString());
+        globalObj.set("value", value.toStdString());
+        globals.add(globalObj);
+    }
+    if (globals.size() > 0) topObj.set("globals", globals);
+
+    //blocks
+    Poco::JSON::Array blocks;
+    std::map<size_t, const GraphBlock*> uidToBlock;
+    for (const auto *obj : graphObjects)
+    {
+        const auto block = dynamic_cast<const GraphBlock *>(obj);
+        if (block == nullptr) continue;
+        if (block->isGraphWidget()) continue;
+        uidToBlock[block->uid()] = block;
+
+        //copy in the the id and path
+        Poco::JSON::Object blockObj;
+        blockObj.set("id", block->getId().toStdString());
+        blockObj.set("path", block->getBlockDescPath());
+
+        //TODO threadPool from block->getAffinityZone()
+
+        //block description args are in the same format
+        const auto desc = block->getBlockDesc();
+        if (desc->has("args")) blockObj.set("args", desc->get("args"));
+
+        //copy in the named calls in array format
+        Poco::JSON::Array calls;
+        if (desc->isArray("calls")) for (const auto &elem : *desc->getArray("calls"))
+        {
+            const auto callObj = elem.extract<Poco::JSON::Object::Ptr>();
+            Poco::JSON::Array call;
+            call.add(callObj->get("name"));
+            for (const auto &arg : *callObj->getArray("args")) call.add(arg);
+            calls.add(call);
+        }
+        blockObj.set("calls", calls);
+
+        //copy in the parameters as local variables
+        Poco::JSON::Array locals;
+        for (const auto &name : block->getProperties())
+        {
+            Poco::JSON::Object local;
+            local.set("name", name.toStdString());
+            local.set("value", block->getPropertyValue(name).toStdString());
+            locals.add(local);
+        }
+        blockObj.set("locals", locals);
+
+        blocks.add(blockObj);
+    }
+    topObj.set("blocks", blocks);
+
+    //connections
+    Poco::JSON::Array connections;
+    for (const auto &connInfo : TopologyEval::getConnectionInfo(graphObjects))
+    {
+        //the block may have been filtered out
+        //check that its found in the mapping
+        auto srcIt = uidToBlock.find(connInfo.srcBlockUID);
+        if (srcIt == uidToBlock.end()) continue;
+        auto dstIt = uidToBlock.find(connInfo.dstBlockUID);
+        if (dstIt == uidToBlock.end()) continue;
+
+        //create the connection information in order
+        Poco::JSON::Array connArr;
+        connArr.add(srcIt->second->getId().toStdString());
+        connArr.add(connInfo.srcPort);
+        connArr.add(dstIt->second->getId().toStdString());
+        connArr.add(connInfo.dstPort);
+        connections.add(connArr);
+    }
+    topObj.set("connections", connections);
+
+    //write to file
+    try
+    {
+        std::ofstream outFile(fileName.toStdString().c_str());
+        topObj.stringify(outFile, 4/*indent*/);
+    }
+    catch (const std::exception &ex)
+    {
+        poco_error_f2(_logger, "Error exporting %s: %s", fileName, std::string(ex.what()));
+    }
+}

--- a/GraphEditor/GraphEditorTabs.hpp
+++ b/GraphEditor/GraphEditorTabs.hpp
@@ -34,6 +34,8 @@ private slots:
     void handleClose(int);
     void handleClose(GraphEditor *editor);
     void handleExit(QCloseEvent *event);
+    void handleExport(void);
+    void handleExportAs(void);
 
 private:
     void doReloadDialog(GraphEditor *editor);

--- a/MainWindow/MainActions.cpp
+++ b/MainWindow/MainActions.cpp
@@ -167,4 +167,12 @@ MainActions::MainActions(QObject *parent):
 
     reloadPluginsAction = new QAction(makeIconFromTheme("view-refresh"), tr("Reload plugin registry"), this);
     reloadPluginsAction->setStatusTip(tr("Stop evaluation, reload plugins, resume evaluation"));
+
+    exportAction = new QAction(makeIconFromTheme("document-export"), tr("Export to JSON topology"), this);
+    exportAction->setStatusTip(tr("Export the current design to the JSON topology format"));
+    exportAction->setShortcut(QKeySequence("CTRL+E"));
+
+    exportAsAction = new QAction(makeIconFromTheme("document-export"), tr("Export to JSON topology as..."), this);
+    exportAsAction->setStatusTip(tr("Export the current design to the JSON topology format as..."));
+    exportAsAction->setShortcut(QKeySequence("CTRL+SHIFT+E"));
 }

--- a/MainWindow/MainActions.hpp
+++ b/MainWindow/MainActions.hpp
@@ -67,4 +67,6 @@ public:
     QAction *decrementAction;
     QAction *fullScreenViewAction;
     QAction *reloadPluginsAction;
+    QAction *exportAction;
+    QAction *exportAsAction;
 };

--- a/MainWindow/MainMenu.cpp
+++ b/MainWindow/MainMenu.cpp
@@ -27,6 +27,9 @@ MainMenu::MainMenu(QMainWindow *parent, MainActions *actions):
     fileMenu->addAction(actions->saveAsAction);
     fileMenu->addAction(actions->saveAllAction);
     fileMenu->addAction(actions->reloadAction);
+    exportMenu = fileMenu->addMenu(makeIconFromTheme("document-export"), tr("E&xport"));
+    exportMenu->addAction(actions->exportAction);
+    exportMenu->addAction(actions->exportAsAction);
     fileMenu->addAction(actions->closeAction);
     fileMenu->addSeparator();
     fileMenu->addAction(actions->exitAction);

--- a/MainWindow/MainMenu.hpp
+++ b/MainWindow/MainMenu.hpp
@@ -23,6 +23,7 @@ public:
     MainMenu(QMainWindow *parent, MainActions *actions);
 
     QMenu *fileMenu;
+    QMenu *exportMenu;
     QMenu *editMenu;
     QMenu *affinityZoneMenu;
     QMenu *moveGraphObjectsMenu;

--- a/MainWindow/MainToolBar.cpp
+++ b/MainWindow/MainToolBar.cpp
@@ -15,6 +15,7 @@ MainToolBar::MainToolBar(QWidget *parent, MainActions *actions):
     this->addAction(actions->saveAsAction);
     this->addAction(actions->saveAllAction);
     this->addAction(actions->reloadAction);
+    this->addAction(actions->exportAction);
     this->addAction(actions->closeAction);
     this->addSeparator();
 


### PR DESCRIPTION
A design can be exported to a simplified JSON topology format that can be executed by the PothosUtil --run-topology command. This should help command line deployments and debugging blocks. This adds an export menu and export menu actions (export and export as). Use keyboard shortcut ctrl+e to export a design to the same file name (but with .json extension). Or use ctrl+shift+e to open an export as file dialog.

* resolves #114 