### PR TITLE
Edit override

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ This this the changelog file for the Pothos GUI toolkit.
 Release 0.5.0 (pending)
 ==========================
 
+- Parameter edit mode to switch between default and line entry
 - Finer grained connection management in Topology evaluator
 - Support for querying and applying block description overlays
 

--- a/GraphObjects/GraphBlock.cpp
+++ b/GraphObjects/GraphBlock.cpp
@@ -229,6 +229,18 @@ void GraphBlock::setPropertyName(const QString &key, const QString &name)
     this->markChanged();
 }
 
+QString GraphBlock::getPropertyEditMode(const QString &key) const
+{
+    auto it = _impl->propertiesEditMode.find(key);
+    if (it != _impl->propertiesEditMode.end()) return it->second;
+    return "";
+}
+
+void GraphBlock::setPropertyEditMode(const QString &key, const QString &mode)
+{
+    _impl->propertiesEditMode[key] = mode;
+}
+
 /*!
  * determine if a value is valid (boolean true)
  * empty data types are considered to be false.
@@ -916,6 +928,8 @@ Poco::JSON::Object::Ptr GraphBlock::serialize(void) const
         Poco::JSON::Object::Ptr jPropObj(new Poco::JSON::Object);
         jPropObj->set("key", propKey.toStdString());
         jPropObj->set("value", this->getPropertyValue(propKey).toStdString());
+        auto editMode = this->getPropertyEditMode(propKey).toStdString();
+        if (not editMode.empty()) jPropObj->set("editMode", editMode);
         jPropsObj->add(jPropObj);
     }
     obj->set("properties", jPropsObj);
@@ -974,6 +988,10 @@ void GraphBlock::deserialize(Poco::JSON::Object::Ptr obj)
         const auto jPropObj = properties->getObject(i);
         const auto propKey = QString::fromStdString(jPropObj->getValue<std::string>("key"));
         this->setPropertyValue(propKey, QString::fromStdString(jPropObj->getValue<std::string>("value")));
+        if (jPropObj->has("editMode"))
+        {
+            this->setPropertyEditMode(propKey, QString::fromStdString(jPropObj->getValue<std::string>("editMode")));
+        }
     }
 
     //load port description and init from it -- in the case eval fails

--- a/GraphObjects/GraphBlock.cpp
+++ b/GraphObjects/GraphBlock.cpp
@@ -988,10 +988,7 @@ void GraphBlock::deserialize(Poco::JSON::Object::Ptr obj)
         const auto jPropObj = properties->getObject(i);
         const auto propKey = QString::fromStdString(jPropObj->getValue<std::string>("key"));
         this->setPropertyValue(propKey, QString::fromStdString(jPropObj->getValue<std::string>("value")));
-        if (jPropObj->has("editMode"))
-        {
-            this->setPropertyEditMode(propKey, QString::fromStdString(jPropObj->getValue<std::string>("editMode")));
-        }
+        this->setPropertyEditMode(propKey, QString::fromStdString(jPropObj->optValue<std::string>("editMode", "")));
     }
 
     //load port description and init from it -- in the case eval fails

--- a/GraphObjects/GraphBlock.hpp
+++ b/GraphObjects/GraphBlock.hpp
@@ -66,6 +66,13 @@ public:
     QString getPropertyName(const QString &key) const;
     void setPropertyName(const QString &key, const QString &name);
 
+    /*!
+     * Editable widget can be in default mode "" or "raw" mode.
+     * Future modes may be possible - like multi-line support.
+     */
+    QString getPropertyEditMode(const QString &key) const;
+    void setPropertyEditMode(const QString &key, const QString &mode);
+
     //! Get the property display text: varies from actual value, enum name, error...
     QString getPropertyDisplayText(const QString &key) const;
 

--- a/GraphObjects/GraphBlockImpl.hpp
+++ b/GraphObjects/GraphBlockImpl.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -39,6 +39,7 @@ struct GraphBlock::Impl
     std::vector<QStaticText> propertiesText;
     std::map<QString, QString> propertiesValues;
     std::map<QString, QString> propertiesNames;
+    std::map<QString, QString> propertiesEditMode;
     std::map<QString, QString> propertiesPreview;
     std::map<QString, Poco::JSON::Array::Ptr> propertiesPreviewArgs;
     std::map<QString, Poco::JSON::Object::Ptr> propertiesPreviewKwargs;

--- a/PropertiesPanel/BlockPropertiesPanel.cpp
+++ b/PropertiesPanel/BlockPropertiesPanel.cpp
@@ -58,7 +58,7 @@ BlockPropertiesPanel::BlockPropertiesPanel(GraphBlock *block, QWidget *parent):
     //id
     {
         const Poco::JSON::Object::Ptr paramDesc(new Poco::JSON::Object());
-        _idLineEdit = new PropertyEditWidget(_block->getId(), paramDesc, this);
+        _idLineEdit = new PropertyEditWidget(_block->getId(), paramDesc, "", this);
         _formLayout->addRow(_idLineEdit->makeFormLabel(tr("ID"), this), _idLineEdit);
         connect(_idLineEdit, SIGNAL(widgetChanged(void)), this, SLOT(handleWidgetChanged(void)));
         connect(_idLineEdit, SIGNAL(widgetChanged(void)), _block, SIGNAL(triggerEvalEvent(void)));
@@ -100,9 +100,10 @@ BlockPropertiesPanel::BlockPropertiesPanel(GraphBlock *block, QWidget *parent):
     for (const auto &propKey : _block->getProperties())
     {
         auto paramDesc = _block->getParamDesc(propKey);
+        const auto editMode = _block->getPropertyEditMode(propKey);
 
         //create editable widget
-        auto editWidget = new PropertyEditWidget(_block->getPropertyValue(propKey), paramDesc, this);
+        auto editWidget = new PropertyEditWidget(_block->getPropertyValue(propKey), paramDesc, editMode, this);
         connect(editWidget, SIGNAL(widgetChanged(void)), this, SLOT(handleWidgetChanged(void)));
         connect(editWidget, SIGNAL(widgetChanged(void)), _block, SIGNAL(triggerEvalEvent(void)));
         connect(editWidget, SIGNAL(entryChanged(void)), this, SLOT(handleWidgetChanged(void)));
@@ -324,6 +325,7 @@ void BlockPropertiesPanel::handleCommit(void)
         {
             propertiesModified.push_back(_block->getPropertyName(propKey));
         }
+        _block->setPropertyEditMode(propKey, _propIdToEditWidget[propKey]->editMode());
     }
 
     //was the ID changed?

--- a/PropertiesPanel/GraphPropertiesPanel.cpp
+++ b/PropertiesPanel/GraphPropertiesPanel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2016 Josh Blum
+// Copyright (c) 2015-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "MainWindow/FormLayout.hpp"
@@ -284,7 +284,7 @@ void GraphPropertiesPanel::createVariableEditWidget(const QString &name)
 
     //create edit widget
     const Poco::JSON::Object::Ptr paramDesc(new Poco::JSON::Object());
-    auto editWidget = new PropertyEditWidget(_graphEditor->getGlobalExpression(name), paramDesc, this);
+    auto editWidget = new PropertyEditWidget(_graphEditor->getGlobalExpression(name), paramDesc, "", this);
     connect(editWidget, SIGNAL(widgetChanged(void)), this, SLOT(updateAllVariableForms(void)));
     //connect(editWidget, SIGNAL(entryChanged(void)), this, SLOT(updateAllVariableForms(void)));
     connect(editWidget, SIGNAL(commitRequested(void)), this, SLOT(handleCommit(void)));

--- a/PropertiesPanel/PropertyEditWidget.cpp
+++ b/PropertiesPanel/PropertyEditWidget.cpp
@@ -31,7 +31,7 @@ PropertyEditWidget::PropertyEditWidget(const QString &initialValue, const Poco::
     _modeLayout(new QHBoxLayout()),
     _editParent(parent),
     _initialEditMode(editMode),
-    _forceLineWidget(editMode == "raw")
+    _editMode(editMode)
 {
     //setup entry timer - timeout acts like widget changed
     _entryTimer->setSingleShot(true);
@@ -89,7 +89,7 @@ void PropertyEditWidget::reloadParamDesc(const Poco::JSON::Object::Ptr &paramDes
 
     //use line the line edit when forced by the button
     _modeButton->setVisible(widgetType != "LineEdit");
-    if (_forceLineWidget) widgetType = "LineEdit";
+    if (_editMode == "raw") widgetType = "LineEdit";
 
     //lookup the plugin to get the entry widget factory
     const auto plugin = Pothos::PluginRegistry::get(Pothos::PluginPath("/gui/EntryWidgets").join(widgetType));
@@ -158,7 +158,7 @@ const QString &PropertyEditWidget::initialEditMode(void) const
 
 QString PropertyEditWidget::editMode(void) const
 {
-    return _forceLineWidget?"raw":"";
+    return _editMode;
 }
 
 QLabel *PropertyEditWidget::makeFormLabel(const QString &text, QWidget *parent)
@@ -192,7 +192,7 @@ void PropertyEditWidget::updateInternals(void)
     if (_formLabel) _formLabel->setText(formLabelText);
 
     //swap mode button arrow based on state
-    _modeButton->setArrowType(_forceLineWidget?Qt::LeftArrow:Qt::RightArrow);
+    _modeButton->setArrowType((_editMode=="raw")?Qt::LeftArrow:Qt::RightArrow);
 
     //set background color when its valid
     if (_bgColor.isValid()) _editWidget->setStyleSheet(
@@ -222,7 +222,8 @@ void PropertyEditWidget::handleCommitRequested(void)
 
 void PropertyEditWidget::handleModeButtonClicked(void)
 {
-    _forceLineWidget = not _forceLineWidget;
+    if (_editMode.isEmpty()) _editMode = "raw";
+    else _editMode = "";
     this->reloadParamDesc(_lastParamDesc);
 }
 

--- a/PropertiesPanel/PropertyEditWidget.cpp
+++ b/PropertiesPanel/PropertyEditWidget.cpp
@@ -20,7 +20,7 @@
  */
 static const long UPDATE_TIMER_MS = 500;
 
-PropertyEditWidget::PropertyEditWidget(const QString &initialValue, const Poco::JSON::Object::Ptr &paramDesc, QWidget *parent):
+PropertyEditWidget::PropertyEditWidget(const QString &initialValue, const Poco::JSON::Object::Ptr &paramDesc, const QString &editMode, QWidget *parent):
     _initialValue(initialValue),
     _editWidget(nullptr),
     _errorLabel(new QLabel(this)),
@@ -30,7 +30,8 @@ PropertyEditWidget::PropertyEditWidget(const QString &initialValue, const Poco::
     _modeButton(new QToolButton(this)),
     _modeLayout(new QHBoxLayout()),
     _editParent(parent),
-    _forceLineWidget(false)
+    _initialEditMode(editMode),
+    _forceLineWidget(editMode == "raw")
 {
     //setup entry timer - timeout acts like widget changed
     _entryTimer->setSingleShot(true);
@@ -117,7 +118,8 @@ const QString &PropertyEditWidget::initialValue(void) const
 
 bool PropertyEditWidget::changed(void) const
 {
-    return this->value() != this->initialValue();
+    return (this->value() != this->initialValue()) or
+        (this->editMode() != this->initialEditMode());
 }
 
 QString PropertyEditWidget::value(void) const
@@ -147,6 +149,16 @@ void PropertyEditWidget::setBackgroundColor(const QColor &color)
 {
     _bgColor = color;
     this->updateInternals();
+}
+
+const QString &PropertyEditWidget::initialEditMode(void) const
+{
+    return _initialEditMode;
+}
+
+QString PropertyEditWidget::editMode(void) const
+{
+    return _forceLineWidget?"raw":"";
 }
 
 QLabel *PropertyEditWidget::makeFormLabel(const QString &text, QWidget *parent)

--- a/PropertiesPanel/PropertyEditWidget.cpp
+++ b/PropertiesPanel/PropertyEditWidget.cpp
@@ -6,7 +6,9 @@
 #include <QLabel>
 #include <QLocale>
 #include <QTimer>
+#include <QToolButton>
 #include <QVBoxLayout>
+#include <QHBoxLayout>
 #include <Pothos/Plugin.hpp>
 #include <Poco/Logger.h>
 
@@ -25,16 +27,30 @@ PropertyEditWidget::PropertyEditWidget(const QString &initialValue, const Poco::
     _formLabel(nullptr),
     _entryTimer(new QTimer(this)),
     _editLayout(new QVBoxLayout(this)),
-    _editParent(parent)
+    _modeButton(new QToolButton(this)),
+    _modeLayout(new QHBoxLayout()),
+    _editParent(parent),
+    _forceLineWidget(false)
 {
     //setup entry timer - timeout acts like widget changed
     _entryTimer->setSingleShot(true);
     _entryTimer->setInterval(UPDATE_TIMER_MS);
     connect(_entryTimer, SIGNAL(timeout(void)), this, SIGNAL(widgetChanged(void)));
 
+    //setup edit mode button
+    _modeButton->setFixedSize(QSize(20, 20));
+    //focus color is distracting, dont enable focus
+    _modeButton->setFocusPolicy(Qt::NoFocus);
+    connect(_modeButton, SIGNAL(clicked(void)), this, SLOT(handleModeButtonClicked(void)));
+
     //layout internal widgets
+    _editLayout->setSpacing(0);
     _editLayout->setContentsMargins(QMargins());
+    _editLayout->addLayout(_modeLayout);
     _editLayout->addWidget(_errorLabel);
+    _modeLayout->setSpacing(3);
+    _modeLayout->setContentsMargins(QMargins());
+    _modeLayout->addWidget(_modeButton, 0, Qt::AlignRight);
 
     //initialize edit widget
     this->reloadParamDesc(paramDesc);
@@ -48,6 +64,8 @@ PropertyEditWidget::~PropertyEditWidget(void)
 
 void PropertyEditWidget::reloadParamDesc(const Poco::JSON::Object::Ptr &paramDesc)
 {
+    _lastParamDesc = paramDesc;
+
     //value to set on replaced widget
     QString newValue = this->initialValue();
     if (_editWidget != nullptr) newValue = this->value();
@@ -68,13 +86,17 @@ void PropertyEditWidget::reloadParamDesc(const Poco::JSON::Object::Ptr &paramDes
         widgetType = "LineEdit";
     }
 
+    //use line the line edit when forced by the button
+    _modeButton->setVisible(widgetType != "LineEdit");
+    if (_forceLineWidget) widgetType = "LineEdit";
+
     //lookup the plugin to get the entry widget factory
     const auto plugin = Pothos::PluginRegistry::get(Pothos::PluginPath("/gui/EntryWidgets").join(widgetType));
     const auto &factory = plugin.getObject().extract<Pothos::Callable>();
     _editWidget = factory.call<QWidget *>(paramDesc, static_cast<QWidget *>(_editParent));
     _editWidget->setLocale(QLocale::C);
     _editWidget->setObjectName("BlockPropertiesEditWidget"); //style-sheet id name
-    _editLayout->insertWidget(0, _editWidget);
+    _modeLayout->insertWidget(0, _editWidget, 1);
 
     //initialize value
     this->setValue(newValue);
@@ -121,10 +143,10 @@ void PropertyEditWidget::setErrorMsg(const QString &errorMsg)
     this->updateInternals();
 }
 
-void PropertyEditWidget::setBackgroundColor(const QColor color)
+void PropertyEditWidget::setBackgroundColor(const QColor &color)
 {
-    _editWidget->setStyleSheet(QString("#BlockPropertiesEditWidget{background:%1;color:%2;}")
-        .arg(color.name()).arg((color.lightnessF() > 0.5)?"black":"white"));
+    _bgColor = color;
+    this->updateInternals();
 }
 
 QLabel *PropertyEditWidget::makeFormLabel(const QString &text, QWidget *parent)
@@ -156,6 +178,14 @@ void PropertyEditWidget::updateInternals(void)
         .arg(this->changed()?"*":"");
     if (hasUnits) formLabelText += QString("<br /><i>%1</i>").arg(_unitsStr);
     if (_formLabel) _formLabel->setText(formLabelText);
+
+    //swap mode button arrow based on state
+    _modeButton->setArrowType(_forceLineWidget?Qt::LeftArrow:Qt::RightArrow);
+
+    //set background color when its valid
+    if (_bgColor.isValid()) _editWidget->setStyleSheet(
+        QString("#BlockPropertiesEditWidget{background:%1;color:%2;}")
+        .arg(_bgColor.name()).arg((_bgColor.lightnessF() > 0.5)?"black":"white"));
 }
 
 void PropertyEditWidget::handleWidgetChanged(void)
@@ -176,6 +206,12 @@ void PropertyEditWidget::handleCommitRequested(void)
     this->flushEvents();
     this->updateInternals();
     emit this->commitRequested();
+}
+
+void PropertyEditWidget::handleModeButtonClicked(void)
+{
+    _forceLineWidget = not _forceLineWidget;
+    this->reloadParamDesc(_lastParamDesc);
 }
 
 void PropertyEditWidget::cancelEvents(void)

--- a/PropertiesPanel/PropertyEditWidget.hpp
+++ b/PropertiesPanel/PropertyEditWidget.hpp
@@ -29,7 +29,7 @@ public:
      * Make a new edit widget from a JSON description.
      * The initial value allows the widget to determine if a change occurred.
      */
-    PropertyEditWidget(const QString &initialValue, const Poco::JSON::Object::Ptr &paramDesc, QWidget *parent);
+    PropertyEditWidget(const QString &initialValue, const Poco::JSON::Object::Ptr &paramDesc, const QString &editMode, QWidget *parent);
 
     ~PropertyEditWidget(void);
 
@@ -56,6 +56,12 @@ public:
 
     //! Set the background color of the edit widget
     void setBackgroundColor(const QColor &color);
+
+    //! Original edit mode applied to this widget
+    const QString &initialEditMode(void) const;
+
+    //! get the current edit mode
+    QString editMode(void) const;
 
     /*!
      * Make a label that will track the widget's status.
@@ -102,6 +108,7 @@ private:
     QHBoxLayout *_modeLayout;
     QWidget *_editParent;
     QColor _bgColor;
+    QString _initialEditMode;
     bool _forceLineWidget;
     Poco::JSON::Object::Ptr _lastParamDesc;
 };

--- a/PropertiesPanel/PropertyEditWidget.hpp
+++ b/PropertiesPanel/PropertyEditWidget.hpp
@@ -109,6 +109,6 @@ private:
     QWidget *_editParent;
     QColor _bgColor;
     QString _initialEditMode;
-    bool _forceLineWidget;
+    QString _editMode;
     Poco::JSON::Object::Ptr _lastParamDesc;
 };

--- a/PropertiesPanel/PropertyEditWidget.hpp
+++ b/PropertiesPanel/PropertyEditWidget.hpp
@@ -11,7 +11,9 @@
 
 class QLabel;
 class QTimer;
+class QToolButton;
 class QVBoxLayout;
+class QHBoxLayout;
 
 /*!
  * The property edit widget creates an entry widget through a JSON description.
@@ -53,7 +55,7 @@ public:
     void setErrorMsg(const QString &errorMsg);
 
     //! Set the background color of the edit widget
-    void setBackgroundColor(const QColor color);
+    void setBackgroundColor(const QColor &color);
 
     /*!
      * Make a label that will track the widget's status.
@@ -83,6 +85,7 @@ private slots:
     void handleWidgetChanged(void);
     void handleEntryChanged(void);
     void handleCommitRequested(void);
+    void handleModeButtonClicked(void);
 
 private:
     void updateInternals(void);
@@ -95,5 +98,10 @@ private:
     QString _unitsStr;
     QTimer *_entryTimer;
     QVBoxLayout *_editLayout;
+    QToolButton *_modeButton;
+    QHBoxLayout *_modeLayout;
     QWidget *_editParent;
+    QColor _bgColor;
+    bool _forceLineWidget;
+    Poco::JSON::Object::Ptr _lastParamDesc;
 };


### PR DESCRIPTION
Support a configurable edit mode in parameter entry to switch between line entries and default widget. This lets one enter variables in boxes that were previously numbers only, like a spin-box. There is a button on all param entry widgets that are not line entry to switch between the two modes. The mode is saved with the topology.

* Resolves https://github.com/pothosware/pothos-gui/issues/96