### PR TITLE
Use qt json and other qt classes

### DIFF
--- a/AffinitySupport/AffinityZoneEditor.cpp
+++ b/AffinitySupport/AffinityZoneEditor.cpp
@@ -155,35 +155,35 @@ void AffinityZoneEditor::loadFromConfig(const QJsonObject &config)
     if (config.contains("color"))
     {
         _colorPicker->blockSignals(true);
-        _colorPicker->setCurrentColor(QColor(config.value("color").toString()));
+        _colorPicker->setCurrentColor(QColor(config["color"].toString()));
         _colorPicker->blockSignals(false);
     }
     if (config.contains("hostUri"))
     {
-        this->selectThisUri(config.value("hostUri").toString());
+        this->selectThisUri(config["hostUri"].toString());
     }
     if (config.contains("processName"))
     {
-        _processNameEdit->setText(config.value("processName").toString());
+        _processNameEdit->setText(config["processName"].toString());
     }
     if (config.contains("numThreads"))
     {
-        _numThreadsSpin->setValue(config.value("numThreads").toInt());
+        _numThreadsSpin->setValue(config["numThreads"].toInt());
     }
     if (config.contains("priority"))
     {
-        _prioritySpin->setValue(int(config.value("priority").toDouble()*100));
+        _prioritySpin->setValue(int(config["priority"].toDouble()*100));
     }
     if (config.contains("affinityMode") and config.contains("affinity"))
     {
-        const auto mask = config.value("affinity").toArray();
+        const auto mask = config["affinity"].toArray();
         std::vector<int> selection;
         for (int i = 0; i < mask.size(); i++) selection.push_back(mask.at(i).toInt());
-        _cpuSelection->setup(config.value("affinityMode").toString(), selection);
+        _cpuSelection->setup(config["affinityMode"].toString(), selection);
     }
     if (config.contains("yieldMode"))
     {
-        const auto mode = config.value("yieldMode").toString();
+        const auto mode = config["yieldMode"].toString();
         for (int i = 0; i < _yieldModeBox->count(); i++)
         {
             if (_yieldModeBox->itemData(i).toString() == mode) _yieldModeBox->setCurrentIndex(i);

--- a/AffinitySupport/AffinityZoneEditor.hpp
+++ b/AffinitySupport/AffinityZoneEditor.hpp
@@ -1,12 +1,11 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
 #include <Pothos/Config.hpp>
 #include <QWidget>
 #include <QColor>
-#include <Poco/JSON/Object.h>
-#include <Poco/JSON/Array.h>
+#include <QJsonObject>
 #include <Pothos/System/NumaInfo.hpp>
 #include <vector>
 #include <map>
@@ -33,10 +32,10 @@ public:
     }
 
     //! load the settings from a JSON object
-    void loadFromConfig(const Poco::JSON::Object::Ptr &config);
+    void loadFromConfig(const QJsonObject &config);
 
     //! query the settings as a JSON object
-    Poco::JSON::Object::Ptr getCurrentConfig(void) const;
+    QJsonObject getCurrentConfig(void) const;
 
     //! Get the current color set on this editor
     QColor color(void) const;

--- a/AffinitySupport/AffinityZonesDock.cpp
+++ b/AffinitySupport/AffinityZonesDock.cpp
@@ -161,8 +161,8 @@ AffinityZoneEditor *AffinityZonesDock::createZoneFromName(const QString &zoneNam
         }
         else
         {
-            poco_error_f2(Poco::Logger::get("PothosGui.AffinityZonesDock"),
-                "Failed to load editor for zone '%s' -- %s",
+            static auto &logger = Poco::Logger::get("PothosGui.AffinityZonesDock");
+            logger.error("Failed to load editor for zone '%s' -- %s",
                 zoneName.toStdString(), parseError.errorString().toStdString());
         }
     }

--- a/AffinitySupport/AffinityZonesDock.cpp
+++ b/AffinitySupport/AffinityZonesDock.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "MainWindow/IconUtils.hpp"
@@ -15,10 +15,9 @@
 #include <QLineEdit>
 #include <QTabWidget>
 #include <QSignalMapper>
-#include <Poco/JSON/Parser.h>
+#include <QJsonDocument>
 #include <Poco/Logger.h>
 #include <cassert>
-#include <sstream>
 
 static AffinityZonesDock *globalAffinityZonesDock = nullptr;
 
@@ -107,7 +106,7 @@ QColor AffinityZonesDock::zoneToColor(const QString &zone)
     return QColor();
 }
 
-Poco::JSON::Object::Ptr AffinityZonesDock::zoneToConfig(const QString &zone)
+QJsonObject AffinityZonesDock::zoneToConfig(const QString &zone)
 {
     for (int i = 0; i < _editorsTabs->count(); i++)
     {
@@ -115,7 +114,7 @@ Poco::JSON::Object::Ptr AffinityZonesDock::zoneToConfig(const QString &zone)
         assert(editor != nullptr);
         if (zone == editor->zoneName()) return editor->getCurrentConfig();
     }
-    return Poco::JSON::Object::Ptr();
+    return QJsonObject();
 }
 
 void AffinityZonesDock::handleTabCloseRequested(const int index)
@@ -151,16 +150,21 @@ AffinityZoneEditor *AffinityZonesDock::createZoneFromName(const QString &zoneNam
     if (zoneName == settings->value("AffinityZones/currentZone").toString()) _editorsTabs->setCurrentWidget(editor);
 
     //restore the settings from save -- even if this is a new panel with the same name as a previous one
-    auto json = settings->value("AffinityZones/zones/"+zoneName).toString();
-    if (not json.isEmpty()) try
+    const auto value = settings->value("AffinityZones/zones/"+zoneName);
+    if (value.isValid())
     {
-        const auto result = Poco::JSON::Parser().parse(json.toStdString());
-        auto dataObj = result.extract<Poco::JSON::Object::Ptr>();
-        editor->loadFromConfig(dataObj);
-    }
-    catch (const Poco::JSON::JSONException &ex)
-    {
-        poco_error_f2(Poco::Logger::get("PothosGui.AffinityZonesDock"), "Failed to load editor for zone '%s' -- %s", zoneName.toStdString(), ex.displayText());
+        QJsonParseError parseError;
+        const auto jsonDoc = QJsonDocument::fromJson(value.toByteArray(), &parseError);
+        if (not jsonDoc.isNull())
+        {
+            editor->loadFromConfig(jsonDoc.object());
+        }
+        else
+        {
+            poco_error_f2(Poco::Logger::get("PothosGui.AffinityZonesDock"),
+                "Failed to load editor for zone '%s' -- %s",
+                zoneName.toStdString(), parseError.errorString().toStdString());
+        }
     }
 
     //now connect the changed signal after initialization+restore changes
@@ -214,9 +218,9 @@ void AffinityZonesDock::saveAffinityZoneEditorsState(void)
     {
         auto editor = dynamic_cast<AffinityZoneEditor *>(_editorsTabs->widget(i));
         assert(editor != nullptr);
-        auto dataObj = editor->getCurrentConfig();
-        std::stringstream ss; dataObj->stringify(ss);
-        settings->setValue("AffinityZones/zones/"+editor->zoneName(), QString::fromStdString(ss.str()));
+        const auto jsonDoc = QJsonDocument(editor->getCurrentConfig());
+        const auto value = jsonDoc.toJson(QJsonDocument::Compact);
+        settings->setValue("AffinityZones/zones/"+editor->zoneName(), value);
     }
 
     emit this->zonesChanged();

--- a/AffinitySupport/AffinityZonesDock.hpp
+++ b/AffinitySupport/AffinityZonesDock.hpp
@@ -1,12 +1,11 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
 #include <Pothos/Config.hpp>
 #include <QDockWidget>
-#include <Poco/JSON/Object.h>
-#include <Poco/JSON/Array.h>
 #include <QStringList>
+#include <QJsonObject>
 #include <QColor>
 
 class QMenu;
@@ -42,7 +41,7 @@ public:
     QColor zoneToColor(const QString &zone);
 
     //! Get the config for a particular zone
-    Poco::JSON::Object::Ptr zoneToConfig(const QString &zone);
+    QJsonObject zoneToConfig(const QString &zone);
 
 signals:
 

--- a/AffinitySupport/CpuSelectionWidget.hpp
+++ b/AffinitySupport/CpuSelectionWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2014 Josh Blum
+// Copyright (c) 2014-2016 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -24,7 +24,7 @@ class CpuSelectionWidget : public QWidget
 public:
     CpuSelectionWidget(const std::vector<Pothos::System::NumaInfo> &numaInfos, QWidget *parent);
 
-    void setup(const std::string &mode, const std::vector<size_t> &selection)
+    void setup(const QString &mode, const std::vector<int> &selection)
     {
         for (auto &pair : _itemToSelected) pair.second = false; //unselect all
         if (mode == "NUMA")
@@ -45,7 +45,7 @@ public:
     }
 
     //! get affinity mode for thread pool args
-    std::string mode(void) const
+    QString mode(void) const
     {
         for (const auto &item : _nodeItems)
         {
@@ -59,9 +59,9 @@ public:
     }
 
     //! get affinity selection for thread pool args
-    std::vector<size_t> selection(void) const
+    std::vector<int> selection(void) const
     {
-        std::vector<size_t> nums;
+        std::vector<int> nums;
         if (this->mode() == "NUMA")
         {
             for (const auto &item : _nodeItems)

--- a/BlockTree/BlockCache.cpp
+++ b/BlockTree/BlockCache.cpp
@@ -31,7 +31,8 @@ static QJsonArray queryBlockDescs(const QString &uri)
     }
     catch (const Pothos::Exception &ex)
     {
-        poco_warning_f2(Poco::Logger::get("PothosGui.BlockCache"), "Failed to query JSON Docs from %s - %s", uri.toStdString(), ex.displayText());
+        static auto &logger = Poco::Logger::get("PothosGui.BlockCache");
+        logger.warning("Failed to query JSON Docs from %s - %s", uri.toStdString(), ex.displayText());
     }
 
     return QJsonArray(); //empty JSON array

--- a/BlockTree/BlockCache.hpp
+++ b/BlockTree/BlockCache.hpp
@@ -11,9 +11,8 @@
 #include <QJsonArray>
 #include <map>
 
-#include <Poco/RWLock.h>
-
 class HostExplorerDock;
+class QReadWriteLock;
 
 class BlockCache : public QObject
 {
@@ -24,6 +23,8 @@ public:
     static BlockCache *global(void);
 
     BlockCache(QObject *parent, HostExplorerDock *hostExplorer);
+
+    ~BlockCache(void);
 
     //! Get a block description given the block registry path
     QJsonObject getBlockDescFromPath(const QString &path);
@@ -47,7 +48,7 @@ private:
     QFutureWatcher<QJsonArray> *_watcher;
 
     //storage structures
-    Poco::RWLock _mapMutex;
+    QReadWriteLock *_mapMutex;
     std::map<QString, QJsonArray> _uriToBlockDescs;
     std::map<QString, QJsonObject> _pathToBlockDesc;
 };

--- a/BlockTree/BlockCache.hpp
+++ b/BlockTree/BlockCache.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -7,10 +7,10 @@
 #include <QString>
 #include <QStringList>
 #include <QFutureWatcher>
+#include <QJsonObject>
+#include <QJsonArray>
 #include <map>
-#include <string>
-#include <Poco/JSON/Object.h>
-#include <Poco/JSON/Array.h>
+
 #include <Poco/RWLock.h>
 
 class HostExplorerDock;
@@ -26,10 +26,10 @@ public:
     BlockCache(QObject *parent, HostExplorerDock *hostExplorer);
 
     //! Get a block description given the block registry path
-    Poco::JSON::Object::Ptr getBlockDescFromPath(const std::string &path);
+    QJsonObject getBlockDescFromPath(const QString &path);
 
 signals:
-    void blockDescUpdate(const Poco::JSON::Array::Ptr &);
+    void blockDescUpdate(const QJsonArray &);
     void blockDescReady(void);
 
 public slots:
@@ -44,10 +44,10 @@ private slots:
 private:
     HostExplorerDock *_hostExplorerDock;
     QStringList _allRemoteNodeUris;
-    QFutureWatcher<Poco::JSON::Array::Ptr> *_watcher;
+    QFutureWatcher<QJsonArray> *_watcher;
 
     //storage structures
     Poco::RWLock _mapMutex;
-    std::map<QString, Poco::JSON::Array::Ptr> _uriToBlockDescs;
-    std::map<std::string, Poco::JSON::Object::Ptr> _pathToBlockDesc;
+    std::map<QString, QJsonArray> _uriToBlockDescs;
+    std::map<QString, QJsonObject> _pathToBlockDesc;
 };

--- a/BlockTree/BlockTreeDock.cpp
+++ b/BlockTree/BlockTreeDock.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "MainWindow/IconUtils.hpp"
@@ -39,10 +39,10 @@ BlockTreeDock::BlockTreeDock(QWidget *parent, BlockCache *blockCache, GraphEdito
     layout->addWidget(_searchBox);
 
     _blockTree = new BlockTreeWidget(this->widget(), editorTabs);
-    connect(blockCache, SIGNAL(blockDescUpdate(const Poco::JSON::Array::Ptr &)),
-        _blockTree, SLOT(handleBlockDescUpdate(const Poco::JSON::Array::Ptr &)));
-    connect(_blockTree, SIGNAL(blockDescEvent(const Poco::JSON::Object::Ptr &, bool)),
-        this, SLOT(handleBlockDescEvent(const Poco::JSON::Object::Ptr &, bool)));
+    connect(blockCache, SIGNAL(blockDescUpdate(const QJsonArray &)),
+        _blockTree, SLOT(handleBlockDescUpdate(const QJsonArray &)));
+    connect(_blockTree, SIGNAL(blockDescEvent(const QJsonObject &, bool)),
+        this, SLOT(handleBlockDescEvent(const QJsonObject &, bool)));
     connect(_searchBox, SIGNAL(textChanged(const QString &)), _blockTree, SLOT(handleFilter(const QString &)));
     layout->addWidget(_blockTree);
 
@@ -67,9 +67,9 @@ void BlockTreeDock::handleAdd(void)
     emit addBlockEvent(_blockDesc);
 }
 
-void BlockTreeDock::handleBlockDescEvent(const Poco::JSON::Object::Ptr &blockDesc, bool add)
+void BlockTreeDock::handleBlockDescEvent(const QJsonObject &blockDesc, bool add)
 {
     _blockDesc = blockDesc;
-    _addButton->setEnabled(bool(blockDesc));
+    _addButton->setEnabled(not blockDesc.isEmpty());
     if (add) emit addBlockEvent(_blockDesc);
 }

--- a/BlockTree/BlockTreeDock.hpp
+++ b/BlockTree/BlockTreeDock.hpp
@@ -1,10 +1,10 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
 #include <Pothos/Config.hpp>
 #include <QDockWidget>
-#include <Poco/JSON/Object.h>
+#include <QJsonObject>
 
 class QPushButton;
 class QLineEdit;
@@ -24,7 +24,7 @@ public:
     BlockTreeDock(QWidget *parent, BlockCache *blockCache, GraphEditorTabs *editorTabs);
 
 signals:
-    void addBlockEvent(const Poco::JSON::Object::Ptr &);
+    void addBlockEvent(const QJsonObject &);
 
 public slots:
     void activateFind(void);
@@ -32,11 +32,11 @@ public slots:
 private slots:
     void handleAdd(void);
 
-    void handleBlockDescEvent(const Poco::JSON::Object::Ptr &blockDesc, bool add);
+    void handleBlockDescEvent(const QJsonObject &blockDesc, bool add);
 
 private:
     QPushButton *_addButton;
     QLineEdit *_searchBox;
-    Poco::JSON::Object::Ptr _blockDesc;
+    QJsonObject _blockDesc;
     BlockTreeWidget *_blockTree;
 };

--- a/BlockTree/BlockTreeWidget.cpp
+++ b/BlockTree/BlockTreeWidget.cpp
@@ -16,7 +16,6 @@
 #include <QTimer>
 #include <QPainter>
 #include <QJsonDocument>
-#include <Poco/Logger.h>
 #include <memory>
 
 static const long UPDATE_TIMER_MS = 500;
@@ -153,24 +152,16 @@ void BlockTreeWidget::populate(void)
 {
     for (const auto &blockDescVal : _blockDescs)
     {
-        try
+        const auto blockDesc = blockDescVal.toObject();
+        if (not this->blockDescMatchesFilter(blockDesc)) continue;
+        const auto path = blockDesc["path"].toString();
+        const auto name = blockDesc["name"].toString();
+        for (const auto &categoryVal : blockDesc["categories"].toArray())
         {
-            const auto blockDesc = blockDescVal.toObject();
-            if (not this->blockDescMatchesFilter(blockDesc)) continue;
-            const auto path = blockDesc["path"].toString();
-            const auto name = blockDesc["name"].toString();
-            for (const auto &categoryVal : blockDesc["categories"].toArray())
-            {
-                const auto category = categoryVal.toString().mid(1);
-                const auto key = category.mid(0, category.indexOf('/'));
-                if (_rootNodes.find(key) == _rootNodes.end()) _rootNodes[key] = new BlockTreeWidgetItem(this, key);
-                _rootNodes[key]->load(blockDesc, category + "/" + name);
-            }
-        }
-        catch (const Poco::Exception &ex)
-        {
-            static auto &logger = Poco::Logger::get("PothosGui.BlockTree");
-            logger.error("Failed JSON Doc parse %s", ex.displayText());
+            const auto category = categoryVal.toString().mid(1);
+            const auto key = category.mid(0, category.indexOf('/'));
+            if (_rootNodes.find(key) == _rootNodes.end()) _rootNodes[key] = new BlockTreeWidgetItem(this, key);
+            _rootNodes[key]->load(blockDesc, category + "/" + name);
         }
     }
 

--- a/BlockTree/BlockTreeWidget.cpp
+++ b/BlockTree/BlockTreeWidget.cpp
@@ -163,7 +163,7 @@ void BlockTreeWidget::populate(void)
             {
                 const auto category = categoryVal.toString().mid(1);
                 const auto key = category.mid(0, category.indexOf('/'));
-                if (_rootNodes.find(key) != _rootNodes.end()) _rootNodes[key] = new BlockTreeWidgetItem(this, key);
+                if (_rootNodes.find(key) == _rootNodes.end()) _rootNodes[key] = new BlockTreeWidgetItem(this, key);
                 _rootNodes[key]->load(blockDesc, category + "/" + name);
             }
         }

--- a/BlockTree/BlockTreeWidget.cpp
+++ b/BlockTree/BlockTreeWidget.cpp
@@ -169,7 +169,8 @@ void BlockTreeWidget::populate(void)
         }
         catch (const Poco::Exception &ex)
         {
-            poco_error_f1(Poco::Logger::get("PothosGui.BlockTree"), "Failed JSON Doc parse %s", ex.displayText());
+            static auto &logger = Poco::Logger::get("PothosGui.BlockTree");
+            logger.error("Failed JSON Doc parse %s", ex.displayText());
         }
     }
 

--- a/BlockTree/BlockTreeWidget.hpp
+++ b/BlockTree/BlockTreeWidget.hpp
@@ -4,10 +4,10 @@
 #pragma once
 #include <Pothos/Config.hpp>
 #include <QTreeWidget>
+#include <QJsonArray>
+#include <QJsonObject>
 #include <QString>
 #include <QList>
-#include <Poco/JSON/Object.h>
-#include <Poco/JSON/Array.h>
 #include <map>
 
 class QTimer;
@@ -24,10 +24,10 @@ public:
     BlockTreeWidget(QWidget *parent, GraphEditorTabs *editorTabs);
 
 signals:
-    void blockDescEvent(const Poco::JSON::Object::Ptr &, bool);
+    void blockDescEvent(const QJsonObject &, bool);
 
 public slots:
-    void handleBlockDescUpdate(const Poco::JSON::Array::Ptr &blockDescs);
+    void handleBlockDescUpdate(const QJsonArray &blockDescs);
 
 private slots:
     void handleFilterTimerExpired(void);
@@ -46,7 +46,7 @@ private:
 
     void populate(void);
 
-    bool blockDescMatchesFilter(const Poco::JSON::Object::Ptr &blockDesc);
+    bool blockDescMatchesFilter(const QJsonObject &blockDesc);
 
     QMimeData *mimeData(const QList<QTreeWidgetItem *> items) const;
 
@@ -55,6 +55,6 @@ private:
     QTimer *_filttimer;
     QPoint _dragStartPos;
     QTreeWidgetItem *_dragItem;
-    Poco::JSON::Array::Ptr _blockDescs;
-    std::map<std::string, BlockTreeWidgetItem *> _rootNodes;
+    QJsonArray _blockDescs;
+    std::map<QString, BlockTreeWidgetItem *> _rootNodes;
 };

--- a/BlockTree/BlockTreeWidgetItem.cpp
+++ b/BlockTree/BlockTreeWidgetItem.cpp
@@ -1,20 +1,21 @@
-// Copyright (c) 2014-2014 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "BlockTree/BlockTreeWidgetItem.hpp"
+#include <QJsonArray>
 
-void BlockTreeWidgetItem::load(const Poco::JSON::Object::Ptr &blockDesc, const std::string &category, const size_t depth)
+void BlockTreeWidgetItem::load(const QJsonObject &blockDesc, const QString &category, const size_t depth)
 {
-    const auto slashIndex = category.find("/");
-    const auto catName = category.substr(0, slashIndex);
-    if (slashIndex == std::string::npos)
+    const auto slashIndex = category.indexOf('/');
+    const auto catName = category.mid(0, slashIndex);
+    if (slashIndex == -1)
     {
         _blockDesc = blockDesc;
     }
     else
     {
-        const auto catRest = category.substr(slashIndex+1);
-        const auto key = catRest.substr(0, catRest.find("/"));
+        const auto catRest = category.mid(slashIndex+1);
+        const auto key = catRest.mid(0, catRest.indexOf("/"));
         if (_subNodes.find(key) == _subNodes.end())
         {
             _subNodes[key] = new BlockTreeWidgetItem(this, key);
@@ -42,17 +43,17 @@ void BlockTreeWidgetItem::setToolTipOnRequest(void)
     this->setToolTip(0, doc);
 }
 
-QString BlockTreeWidgetItem::extractDocString(Poco::JSON::Object::Ptr blockDesc)
+QString BlockTreeWidgetItem::extractDocString(const QJsonObject &blockDesc)
 {
-    if (not blockDesc or not blockDesc->isArray("docs")) return "";
+    if (not blockDesc.contains("docs")) return "";
     QString output;
-    output += "<b>" + QString::fromStdString(blockDesc->get("name").convert<std::string>()) + "</b>";
+    output += "<b>" + blockDesc["name"].toString() + "</b>";
     output += "<p>";
-    for (const auto &lineObj : *blockDesc->getArray("docs"))
+    for (const auto &lineVal : blockDesc["docs"].toArray())
     {
-        const auto line = lineObj.extract<std::string>();
-        if (line.empty()) output += "<p /><p>";
-        else output += QString::fromStdString(line)+"\n";
+        const auto line = lineVal.toString();
+        if (line.isEmpty()) output += "<p /><p>";
+        else output += line+"\n";
     }
     output += "</p>";
     return "<div>" + output + "</div>";

--- a/BlockTree/BlockTreeWidgetItem.hpp
+++ b/BlockTree/BlockTreeWidgetItem.hpp
@@ -1,26 +1,26 @@
-// Copyright (c) 2014-2014 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
 #include <Pothos/Config.hpp>
 #include <QTreeWidgetItem>
-#include <Poco/JSON/Object.h>
-#include <string>
+#include <QJsonObject>
+#include <QString>
 #include <map>
 
 class BlockTreeWidgetItem : public QTreeWidgetItem
 {
 public:
     template <typename ParentType>
-    BlockTreeWidgetItem(ParentType *parent, const std::string &name):
-        QTreeWidgetItem(parent, QStringList(QString::fromStdString(name)))
+    BlockTreeWidgetItem(ParentType *parent, const QString &name):
+        QTreeWidgetItem(parent, QStringList(name))
     {
         return;
     }
 
-    void load(const Poco::JSON::Object::Ptr &blockDesc, const std::string &category, const size_t depth = 0);
+    void load(const QJsonObject &blockDesc, const QString &category, const size_t depth = 0);
 
-    Poco::JSON::Object::Ptr getBlockDesc(void) const
+    const QJsonObject &getBlockDesc(void) const
     {
         return _blockDesc;
     }
@@ -31,8 +31,8 @@ private:
 
     void setToolTipOnRequest(void);
 
-    static QString extractDocString(Poco::JSON::Object::Ptr blockDesc);
+    static QString extractDocString(const QJsonObject &blockDesc);
 
-    std::map<std::string, BlockTreeWidgetItem *> _subNodes;
-    Poco::JSON::Object::Ptr _blockDesc;
+    std::map<QString, BlockTreeWidgetItem *> _subNodes;
+    QJsonObject _blockDesc;
 };

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 2.8.9)
 project(PothosGui CXX)
 
 if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
-    find_package(Pothos "0.4.0" CONFIG REQUIRED)
+    find_package(Pothos "0.5.0" CONFIG REQUIRED)
 else()
     find_package(Pothos CONFIG REQUIRED) #in-tree build
 endif()

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,8 @@ This this the changelog file for the Pothos GUI toolkit.
 Release 0.5.0 (pending)
 ==========================
 
+- Require 0.5.0 Pothos framework for DocUtil and BlockEval
+- Switch over to Qt classes for JSON, time, processes, etc...
 - Parameter edit mode to switch between default and line entry
 - Finer grained connection management in Topology evaluator
 - Support for querying and applying block description overlays

--- a/ColorUtils/ColorUtils.cpp
+++ b/ColorUtils/ColorUtils.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSL-1.0
 
 #include "ColorUtils/ColorUtils.hpp"
-#include <Poco/Types.h>
 #include <Pothos/Framework.hpp>
 #include <Pothos/Util/TypeInfo.hpp>
 #include <QPixmap>
@@ -10,6 +9,7 @@
 #include <QReadWriteLock>
 #include <type_traits>
 #include <complex>
+#include <cstdint>
 
 /***********************************************************************
  * color map helper utilities
@@ -88,16 +88,11 @@ ColorMap::ColorMap(void)
     this->registerName(Pothos::DType().name(), Qt::gray);
 
     //integer types
-    registerIntType<char>(Qt::magenta);
-    registerIntType<short>(Qt::yellow);
-    registerIntType<int>(Qt::green);
+    registerIntType<int8_t>(Qt::magenta);
+    registerIntType<int16_t>(Qt::yellow);
+    registerIntType<int32_t>(Qt::green);
     static const QColor orange("#FF7F00");
-    #ifndef POCO_LONG_IS_64_BIT
-    registerIntType<long>(Qt::green);
-    #else
-    registerIntType<long>(orange);
-    #endif
-    registerIntType<long long>(orange);
+    registerIntType<int64_t>(orange);
 
     //floating point
     registerFloatType<float>(Qt::red);

--- a/ColorUtils/ColorUtils.cpp
+++ b/ColorUtils/ColorUtils.cpp
@@ -148,8 +148,9 @@ QColor typeStrToColor(const QString &typeStr_)
     }
 
     //create a new entry
+    const auto color = __typeStrToColor(typeStr);
     QWriteLocker lock(getLookupMutex());
-    return (getColorMap()->at(typeStr) = __typeStrToColor(typeStr));
+    return getColorMap()->emplace(typeStr, color).first->second;
 }
 
 std::map<QString, QColor> getTypeStrToColorMap(void)

--- a/ColorUtils/ColorUtils.hpp
+++ b/ColorUtils/ColorUtils.hpp
@@ -1,15 +1,21 @@
-// Copyright (c) 2013-2014 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
 #include <Pothos/Config.hpp>
 #include <QIcon>
 #include <QColor>
+#include <QString>
 #include <string>
 #include <map>
 
 //! Convert the type name to a displayable color
 QColor typeStrToColor(const std::string &typeStr);
+
+inline QColor typeStrToColor(const QString &typeStr)
+{
+    return typeStrToColor(typeStr.toStdString());
+}
 
 //! Get the map of known type strings to colors
 std::map<std::string, QColor> getTypeStrToColorMap(void);

--- a/ColorUtils/ColorUtils.hpp
+++ b/ColorUtils/ColorUtils.hpp
@@ -6,19 +6,13 @@
 #include <QIcon>
 #include <QColor>
 #include <QString>
-#include <string>
 #include <map>
 
 //! Convert the type name to a displayable color
-QColor typeStrToColor(const std::string &typeStr);
-
-inline QColor typeStrToColor(const QString &typeStr)
-{
-    return typeStrToColor(typeStr.toStdString());
-}
+QColor typeStrToColor(const QString &typeStr);
 
 //! Get the map of known type strings to colors
-std::map<std::string, QColor> getTypeStrToColorMap(void);
+std::map<QString, QColor> getTypeStrToColorMap(void);
 
 //! Create a decorative icon of the color
 QIcon colorToWidgetIcon(const QColor &color);

--- a/ColorUtils/ColorsDialog.cpp
+++ b/ColorUtils/ColorsDialog.cpp
@@ -1,11 +1,10 @@
-// Copyright (c) 2013-2014 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "ColorUtils/ColorsDialog.hpp"
 #include "ColorUtils/ColorUtils.hpp"
 #include <QTreeWidget>
 #include <QVBoxLayout>
-#include <string>
 #include <algorithm>
 
 ColorsDialog::ColorsDialog(QWidget *parent):
@@ -22,14 +21,14 @@ ColorsDialog::ColorsDialog(QWidget *parent):
 
     //query map and sort keys
     const auto typeStrToColorMap = getTypeStrToColorMap();
-    std::vector<std::string> typeStrs;
+    QStringList typeStrs;
     for (const auto &pair : typeStrToColorMap) typeStrs.push_back(pair.first);
     std::sort(typeStrs.begin(), typeStrs.end());
 
     //populate tree with colors
     for (const auto &typeStr : typeStrs)
     {
-        auto item = new QTreeWidgetItem(tree, QStringList(QString::fromStdString(typeStr)));
+        auto item = new QTreeWidgetItem(tree, QStringList(typeStr));
         item->setIcon(0, colorToWidgetIcon(typeStrToColorMap.at(typeStr)));
         tree->addTopLevelItem(item);
     }

--- a/EditWidgets/ColorPicker.cpp
+++ b/EditWidgets/ColorPicker.cpp
@@ -3,6 +3,7 @@
 
 #include <Pothos/Plugin.hpp>
 #include <QJsonObject>
+#include <QJsonArray>
 #define QT_QTCOLORPICKER_IMPORT
 #include <QtColorPicker>
 #include <stdexcept>
@@ -75,11 +76,9 @@ private:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeColorPicker(const QJsonObject &paramDesc, QWidget *parent)
+static QWidget *makeColorPicker(const QJsonArray &, const QJsonObject &kwargs, QWidget *parent)
 {
-    const auto widgetKwargs = paramDesc["widgetKwargs"].toObject();
-
-    return new ColorPicker(parent, widgetKwargs["mode"].toString("default"));
+    return new ColorPicker(parent, kwargs["mode"].toString("default"));
 }
 
 pothos_static_block(registerColorPicker)

--- a/EditWidgets/ColorPicker.cpp
+++ b/EditWidgets/ColorPicker.cpp
@@ -1,8 +1,8 @@
-// Copyright (c) 2016-2016 Josh Blum
+// Copyright (c) 2016-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Plugin.hpp>
-#include <Poco/JSON/Object.h>
+#include <QJsonObject>
 #define QT_QTCOLORPICKER_IMPORT
 #include <QtColorPicker>
 #include <stdexcept>
@@ -14,7 +14,7 @@ class ColorPicker : public QtColorPicker
 {
     Q_OBJECT
 public:
-    ColorPicker(QWidget *parent, const std::string &mode):
+    ColorPicker(QWidget *parent, const QString &mode):
         QtColorPicker(parent),
         _value("black")
     {
@@ -75,13 +75,11 @@ private:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeColorPicker(const Poco::JSON::Object::Ptr &paramDesc, QWidget *parent)
+static QWidget *makeColorPicker(const QJsonObject &paramDesc, QWidget *parent)
 {
-    Poco::JSON::Object::Ptr widgetKwargs(new Poco::JSON::Object());
-    if (paramDesc->has("widgetKwargs")) widgetKwargs = paramDesc->getObject("widgetKwargs");
-    const auto mode = widgetKwargs->optValue<std::string>("mode", "default");
+    const auto widgetKwargs = paramDesc["widgetKwargs"].toObject();
 
-    return new ColorPicker(parent, mode);
+    return new ColorPicker(parent, widgetKwargs["mode"].toString("default"));
 }
 
 pothos_static_block(registerColorPicker)

--- a/EditWidgets/ComboBox.cpp
+++ b/EditWidgets/ComboBox.cpp
@@ -93,13 +93,11 @@ private:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeComboBox(const QJsonObject &paramDesc, QWidget *parent)
+static QWidget *makeComboBox(const QJsonArray &args, const QJsonObject &kwargs, QWidget *parent)
 {
-    const auto widgetKwargs = paramDesc["widgetKwargs"].toObject();
-
     auto comboBox = new ComboBox(parent);
-    comboBox->setEditable(widgetKwargs["editable"].toBool(false));
-    for (const auto &optionVal : paramDesc["options"].toArray())
+    comboBox->setEditable(kwargs["editable"].toBool(false));
+    for (const auto &optionVal : args)
     {
         const auto option = optionVal.toObject();
         comboBox->addItem(option["name"].toString(), option["value"].toString());

--- a/EditWidgets/ComboBox.cpp
+++ b/EditWidgets/ComboBox.cpp
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Plugin.hpp>
-#include <Poco/JSON/Object.h>
+#include <QJsonObject>
+#include <QJsonArray>
 #include <QAbstractItemView>
 #include <QComboBox>
 #include <QLineEdit>
@@ -92,19 +93,16 @@ private:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeComboBox(const Poco::JSON::Object::Ptr &paramDesc, QWidget *parent)
+static QWidget *makeComboBox(const QJsonObject &paramDesc, QWidget *parent)
 {
-    Poco::JSON::Object::Ptr widgetKwargs(new Poco::JSON::Object());
-    if (paramDesc->has("widgetKwargs")) widgetKwargs = paramDesc->getObject("widgetKwargs");
+    const auto widgetKwargs = paramDesc["widgetKwargs"].toObject();
 
     auto comboBox = new ComboBox(parent);
-    comboBox->setEditable(widgetKwargs->optValue<bool>("editable", false));
-    if (paramDesc->isArray("options")) for (const auto &optionObj : *paramDesc->getArray("options"))
+    comboBox->setEditable(widgetKwargs["editable"].toBool(false));
+    for (const auto &optionVal : paramDesc["options"].toArray())
     {
-        const auto option = optionObj.extract<Poco::JSON::Object::Ptr>();
-        comboBox->addItem(
-            QString::fromStdString(option->getValue<std::string>("name")),
-            QString::fromStdString(option->getValue<std::string>("value")));
+        const auto option = optionVal.toObject();
+        comboBox->addItem(option["name"].toString(), option["value"].toString());
     }
     comboBox->doneAddingItems();
     return comboBox;

--- a/EditWidgets/DTypeChooser.cpp
+++ b/EditWidgets/DTypeChooser.cpp
@@ -4,6 +4,7 @@
 #include <Pothos/Framework/DType.hpp>
 #include <Pothos/Plugin.hpp>
 #include <QJsonObject>
+#include <QJsonArray>
 #include <QAbstractItemView>
 #include <QHBoxLayout>
 #include <QComboBox>
@@ -131,11 +132,9 @@ private:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeDTypeChooser(const QJsonObject &paramDesc, QWidget *parent)
+static QWidget *makeDTypeChooser(const QJsonArray &, const QJsonObject &kwargs, QWidget *parent)
 {
-    const auto widgetKwargs = paramDesc["widgetKwargs"].toObject();
-
-    const bool editDimension = widgetKwargs["dim"].toBool(false);
+    const bool editDimension = kwargs["dim"].toBool(false);
 
     auto dtypeChooser = new DTypeChooser(parent, editDimension);
     auto comboBox = dtypeChooser->comboBox();
@@ -146,12 +145,12 @@ static QWidget *makeDTypeChooser(const QJsonObject &paramDesc, QWidget *parent)
         const QString aliasPrefix((mode == 0)? "complex_":"");
         for (int bytes = 64; bytes >= 32; bytes /= 2)
         {
-            if (widgetKwargs.contains(keyPrefix+"float")) comboBox->addItem(QString("%1Float%2").arg(namePrefix).arg(bytes), QString("\"%1float%2\"").arg(aliasPrefix).arg(bytes));
+            if (kwargs.contains(keyPrefix+"float")) comboBox->addItem(QString("%1Float%2").arg(namePrefix).arg(bytes), QString("\"%1float%2\"").arg(aliasPrefix).arg(bytes));
         }
         for (int bytes = 64; bytes >= 8; bytes /= 2)
         {
-            if (widgetKwargs.contains(keyPrefix+"int")) comboBox->addItem(QString("%1Int%2").arg(namePrefix).arg(bytes), QString("\"%1int%2\"").arg(aliasPrefix).arg(bytes));
-            if (widgetKwargs.contains(keyPrefix+"uint")) comboBox->addItem(QString("%1UInt%2").arg(namePrefix).arg(bytes), QString("\"%1uint%2\"").arg(aliasPrefix).arg(bytes));
+            if (kwargs.contains(keyPrefix+"int")) comboBox->addItem(QString("%1Int%2").arg(namePrefix).arg(bytes), QString("\"%1int%2\"").arg(aliasPrefix).arg(bytes));
+            if (kwargs.contains(keyPrefix+"uint")) comboBox->addItem(QString("%1UInt%2").arg(namePrefix).arg(bytes), QString("\"%1uint%2\"").arg(aliasPrefix).arg(bytes));
         }
     }
     return dtypeChooser;

--- a/EditWidgets/DTypeChooser.cpp
+++ b/EditWidgets/DTypeChooser.cpp
@@ -1,9 +1,9 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Framework/DType.hpp>
 #include <Pothos/Plugin.hpp>
-#include <Poco/JSON/Object.h>
+#include <QJsonObject>
 #include <QAbstractItemView>
 #include <QHBoxLayout>
 #include <QComboBox>
@@ -131,28 +131,27 @@ private:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeDTypeChooser(const Poco::JSON::Object::Ptr &paramDesc, QWidget *parent)
+static QWidget *makeDTypeChooser(const QJsonObject &paramDesc, QWidget *parent)
 {
-    Poco::JSON::Object::Ptr widgetKwargs(new Poco::JSON::Object());
-    if (paramDesc->has("widgetKwargs")) widgetKwargs = paramDesc->getObject("widgetKwargs");
+    const auto widgetKwargs = paramDesc["widgetKwargs"].toObject();
 
-    const bool editDimension = widgetKwargs->optValue<bool>("dim", false);
+    const bool editDimension = widgetKwargs["dim"].toBool(false);
 
     auto dtypeChooser = new DTypeChooser(parent, editDimension);
     auto comboBox = dtypeChooser->comboBox();
     for (int mode = 0; mode <= 1; mode++)
     {
-        const std::string keyPrefix((mode == 0)? "c":"");
+        const QString keyPrefix((mode == 0)? "c":"");
         const QString namePrefix((mode == 0)? "Complex ":"");
         const QString aliasPrefix((mode == 0)? "complex_":"");
         for (int bytes = 64; bytes >= 32; bytes /= 2)
         {
-            if (widgetKwargs->has(keyPrefix+"float")) comboBox->addItem(QString("%1Float%2").arg(namePrefix).arg(bytes), QString("\"%1float%2\"").arg(aliasPrefix).arg(bytes));
+            if (widgetKwargs.contains(keyPrefix+"float")) comboBox->addItem(QString("%1Float%2").arg(namePrefix).arg(bytes), QString("\"%1float%2\"").arg(aliasPrefix).arg(bytes));
         }
         for (int bytes = 64; bytes >= 8; bytes /= 2)
         {
-            if (widgetKwargs->has(keyPrefix+"int")) comboBox->addItem(QString("%1Int%2").arg(namePrefix).arg(bytes), QString("\"%1int%2\"").arg(aliasPrefix).arg(bytes));
-            if (widgetKwargs->has(keyPrefix+"uint")) comboBox->addItem(QString("%1UInt%2").arg(namePrefix).arg(bytes), QString("\"%1uint%2\"").arg(aliasPrefix).arg(bytes));
+            if (widgetKwargs.contains(keyPrefix+"int")) comboBox->addItem(QString("%1Int%2").arg(namePrefix).arg(bytes), QString("\"%1int%2\"").arg(aliasPrefix).arg(bytes));
+            if (widgetKwargs.contains(keyPrefix+"uint")) comboBox->addItem(QString("%1UInt%2").arg(namePrefix).arg(bytes), QString("\"%1uint%2\"").arg(aliasPrefix).arg(bytes));
         }
     }
     return dtypeChooser;

--- a/EditWidgets/DoubleSpinBox.cpp
+++ b/EditWidgets/DoubleSpinBox.cpp
@@ -1,8 +1,8 @@
-// Copyright (c) 2014-2015 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Plugin.hpp>
-#include <Poco/JSON/Object.h>
+#include <QJsonObject>
 #include <QDoubleSpinBox>
 #include <limits>
 
@@ -54,16 +54,15 @@ private:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeDoubleSpinBox(const Poco::JSON::Object::Ptr &paramDesc, QWidget *parent)
+static QWidget *makeDoubleSpinBox(const QJsonObject &paramDesc, QWidget *parent)
 {
-    Poco::JSON::Object::Ptr widgetKwargs(new Poco::JSON::Object());
-    if (paramDesc->has("widgetKwargs")) widgetKwargs = paramDesc->getObject("widgetKwargs");
+    const auto widgetKwargs = paramDesc["widgetKwargs"].toObject();
 
     auto spinBox = new DoubleSpinBox(parent);
-    spinBox->setMinimum(widgetKwargs->optValue<double>("minimum", -1e12));
-    spinBox->setMaximum(widgetKwargs->optValue<double>("maximum", +1e12));
-    spinBox->setSingleStep(widgetKwargs->optValue<double>("step", 0.01));
-    spinBox->setDecimals(widgetKwargs->optValue<int>("decimals", 2));
+    spinBox->setMinimum(widgetKwargs["minimum"].toDouble(-1e12));
+    spinBox->setMaximum(widgetKwargs["maximum"].toDouble(+1e12));
+    spinBox->setSingleStep(widgetKwargs["step"].toDouble(0.01));
+    spinBox->setDecimals(widgetKwargs["decimals"].toInt(2));
     return spinBox;
 }
 

--- a/EditWidgets/DoubleSpinBox.cpp
+++ b/EditWidgets/DoubleSpinBox.cpp
@@ -3,6 +3,7 @@
 
 #include <Pothos/Plugin.hpp>
 #include <QJsonObject>
+#include <QJsonArray>
 #include <QDoubleSpinBox>
 #include <limits>
 
@@ -54,15 +55,13 @@ private:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeDoubleSpinBox(const QJsonObject &paramDesc, QWidget *parent)
+static QWidget *makeDoubleSpinBox(const QJsonArray &, const QJsonObject &kwargs, QWidget *parent)
 {
-    const auto widgetKwargs = paramDesc["widgetKwargs"].toObject();
-
     auto spinBox = new DoubleSpinBox(parent);
-    spinBox->setMinimum(widgetKwargs["minimum"].toDouble(-1e12));
-    spinBox->setMaximum(widgetKwargs["maximum"].toDouble(+1e12));
-    spinBox->setSingleStep(widgetKwargs["step"].toDouble(0.01));
-    spinBox->setDecimals(widgetKwargs["decimals"].toInt(2));
+    spinBox->setMinimum(kwargs["minimum"].toDouble(-1e12));
+    spinBox->setMaximum(kwargs["maximum"].toDouble(+1e12));
+    spinBox->setSingleStep(kwargs["step"].toDouble(0.01));
+    spinBox->setDecimals(kwargs["decimals"].toInt(2));
     return spinBox;
 }
 

--- a/EditWidgets/FileEntry.cpp
+++ b/EditWidgets/FileEntry.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Plugin.hpp>
-#include <Poco/JSON/Object.h>
+#include <QJsonObject>
 #include <QWidget>
 #include <QLineEdit>
 #include <QPushButton>
@@ -81,13 +81,11 @@ private:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeFileEntry(const Poco::JSON::Object::Ptr &paramDesc, QWidget *parent)
+static QWidget *makeFileEntry(const QJsonObject &paramDesc, QWidget *parent)
 {
-    Poco::JSON::Object::Ptr widgetKwargs(new Poco::JSON::Object());
-    if (paramDesc->has("widgetKwargs")) widgetKwargs = paramDesc->getObject("widgetKwargs");
+    const auto widgetKwargs = paramDesc["widgetKwargs"].toObject();
 
-    const auto mode = widgetKwargs->optValue<std::string>("mode", "save");
-    return new FileEntry(QString::fromStdString(mode), parent);
+    return new FileEntry(widgetKwargs["mode"].toString("save"), parent);
 }
 
 pothos_static_block(registerFileEntry)

--- a/EditWidgets/FileEntry.cpp
+++ b/EditWidgets/FileEntry.cpp
@@ -3,6 +3,7 @@
 
 #include <Pothos/Plugin.hpp>
 #include <QJsonObject>
+#include <QJsonArray>
 #include <QWidget>
 #include <QLineEdit>
 #include <QPushButton>
@@ -81,11 +82,9 @@ private:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeFileEntry(const QJsonObject &paramDesc, QWidget *parent)
+static QWidget *makeFileEntry(const QJsonArray &, const QJsonObject &kwargs, QWidget *parent)
 {
-    const auto widgetKwargs = paramDesc["widgetKwargs"].toObject();
-
-    return new FileEntry(widgetKwargs["mode"].toString("save"), parent);
+    return new FileEntry(kwargs["mode"].toString("save"), parent);
 }
 
 pothos_static_block(registerFileEntry)

--- a/EditWidgets/LineEdit.cpp
+++ b/EditWidgets/LineEdit.cpp
@@ -3,6 +3,7 @@
 
 #include <Pothos/Plugin.hpp>
 #include <QJsonObject>
+#include <QJsonArray>
 #include <QLineEdit>
 
 /***********************************************************************
@@ -45,7 +46,7 @@ private slots:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeLineEdit(const QJsonObject &, QWidget *parent)
+static QWidget *makeLineEdit(const QJsonArray &, const QJsonObject &, QWidget *parent)
 {
     return new LineEdit(parent);
 }

--- a/EditWidgets/LineEdit.cpp
+++ b/EditWidgets/LineEdit.cpp
@@ -1,8 +1,8 @@
-// Copyright (c) 2014-2014 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Plugin.hpp>
-#include <Poco/JSON/Object.h>
+#include <QJsonObject>
 #include <QLineEdit>
 
 /***********************************************************************
@@ -45,7 +45,7 @@ private slots:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeLineEdit(const Poco::JSON::Object::Ptr &, QWidget *parent)
+static QWidget *makeLineEdit(const QJsonObject &, QWidget *parent)
 {
     return new LineEdit(parent);
 }

--- a/EditWidgets/SpinBox.cpp
+++ b/EditWidgets/SpinBox.cpp
@@ -1,8 +1,8 @@
-// Copyright (c) 2014-2015 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Plugin.hpp>
-#include <Poco/JSON/Object.h>
+#include <QJsonObject>
 #include <QSpinBox>
 #include <limits>
 
@@ -51,14 +51,13 @@ private:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeSpinBox(const Poco::JSON::Object::Ptr &paramDesc, QWidget *parent)
+static QWidget *makeSpinBox(const QJsonObject &paramDesc, QWidget *parent)
 {
-    Poco::JSON::Object::Ptr widgetKwargs(new Poco::JSON::Object());
-    if (paramDesc->has("widgetKwargs")) widgetKwargs = paramDesc->getObject("widgetKwargs");
+    const auto widgetKwargs = paramDesc["widgetKwargs"].toObject();
 
     auto spinBox = new SpinBox(parent);
-    spinBox->setMinimum(widgetKwargs->optValue<int>("minimum", std::numeric_limits<int>::min()));
-    spinBox->setMaximum(widgetKwargs->optValue<int>("maximum", std::numeric_limits<int>::max()));
+    spinBox->setMinimum(widgetKwargs["minimum"].toInt(std::numeric_limits<int>::min()));
+    spinBox->setMaximum(widgetKwargs["maximum"].toInt(std::numeric_limits<int>::max()));
     return spinBox;
 }
 

--- a/EditWidgets/SpinBox.cpp
+++ b/EditWidgets/SpinBox.cpp
@@ -3,6 +3,7 @@
 
 #include <Pothos/Plugin.hpp>
 #include <QJsonObject>
+#include <QJsonArray>
 #include <QSpinBox>
 #include <limits>
 
@@ -51,13 +52,11 @@ private:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeSpinBox(const QJsonObject &paramDesc, QWidget *parent)
+static QWidget *makeSpinBox(const QJsonArray &, const QJsonObject &kwargs, QWidget *parent)
 {
-    const auto widgetKwargs = paramDesc["widgetKwargs"].toObject();
-
     auto spinBox = new SpinBox(parent);
-    spinBox->setMinimum(widgetKwargs["minimum"].toInt(std::numeric_limits<int>::min()));
-    spinBox->setMaximum(widgetKwargs["maximum"].toInt(std::numeric_limits<int>::max()));
+    spinBox->setMinimum(kwargs["minimum"].toInt(std::numeric_limits<int>::min()));
+    spinBox->setMaximum(kwargs["maximum"].toInt(std::numeric_limits<int>::max()));
     return spinBox;
 }
 

--- a/EditWidgets/StringEntry.cpp
+++ b/EditWidgets/StringEntry.cpp
@@ -3,6 +3,7 @@
 
 #include <Pothos/Plugin.hpp>
 #include <QJsonObject>
+#include <QJsonArray>
 #include <QLineEdit>
 
 /***********************************************************************
@@ -51,7 +52,7 @@ private slots:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeStringEntry(const QJsonObject &, QWidget *parent)
+static QWidget *makeStringEntry(const QJsonArray &, const QJsonObject &, QWidget *parent)
 {
     return new StringEntry(parent);
 }

--- a/EditWidgets/StringEntry.cpp
+++ b/EditWidgets/StringEntry.cpp
@@ -1,8 +1,8 @@
-// Copyright (c) 2014-2014 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Plugin.hpp>
-#include <Poco/JSON/Object.h>
+#include <QJsonObject>
 #include <QLineEdit>
 
 /***********************************************************************
@@ -51,7 +51,7 @@ private slots:
 /***********************************************************************
  * Factory function and registration
  **********************************************************************/
-static QWidget *makeStringEntry(const Poco::JSON::Object::Ptr &, QWidget *parent)
+static QWidget *makeStringEntry(const QJsonObject &, QWidget *parent)
 {
     return new StringEntry(parent);
 }

--- a/EvalEngine/BlockEval.hpp
+++ b/EvalEngine/BlockEval.hpp
@@ -6,7 +6,8 @@
 #include <Pothos/Proxy/Proxy.hpp>
 #include <Pothos/Proxy/Environment.hpp>
 #include <Pothos/Exception.hpp>
-#include <Poco/JSON/Object.h>
+#include <QJsonObject>
+#include <QJsonArray>
 #include <QObject>
 #include <QPointer>
 #include <QString>
@@ -37,8 +38,8 @@ struct BlockInfo
     std::map<QString, QString> properties;
     QStringList constantNames; //preserves order
     std::map<QString, QString> constants;
-    std::map<QString, Poco::JSON::Object::Ptr> paramDescs;
-    Poco::JSON::Object::Ptr desc;
+    std::map<QString, QJsonObject> paramDescs;
+    QJsonObject desc;
 };
 
 //! values to pass back to the gui thread to update the block
@@ -46,13 +47,13 @@ struct BlockStatus
 {
     QPointer<GraphBlock> block;
     QPointer<QWidget> widget;
-    std::map<QString, std::string> propertyTypeInfos;
+    std::map<QString, QString> propertyTypeInfos;
     std::map<QString, QString> propertyErrorMsgs;
     QStringList blockErrorMsgs;
-    Poco::JSON::Array::Ptr inPortDesc;
-    Poco::JSON::Array::Ptr outPortDesc;
-    Poco::JSON::Object::Ptr overlayDesc;
-    std::string overlayDescStr;
+    QJsonArray inPortDesc;
+    QJsonArray outPortDesc;
+    QJsonObject overlayDesc;
+    QByteArray overlayDescStr;
     std::chrono::high_resolution_clock::time_point overlayExpired;
 };
 
@@ -90,7 +91,7 @@ public:
      * This is used by the topology evaluation logic to check
      * before making a connection.
      */
-    bool portExists(const std::string &name, const bool isInput) const;
+    bool portExists(const QString &name, const bool isInput) const;
 
     /*!
      * Get the remote proxy block from the evaluator
@@ -139,7 +140,7 @@ private:
     bool hasCriticalChange(void) const;
 
     //! any setters that changed so we can re-call them
-    std::vector<Poco::JSON::Object::Ptr> settersChangedList(void) const;
+    std::vector<QJsonObject> settersChangedList(void) const;
 
     //! detect a change in properties before vs after
     bool didPropKeyHaveChange(const QString &key) const;
@@ -184,7 +185,7 @@ private:
     bool evaluationProcedure(void);
 
     //! Internal helper for error message formatting
-    void reportError(const std::string &action, const Pothos::Exception &ex);
+    void reportError(const QString &action, const Pothos::Exception &ex);
 
     //Tracking state for the eval environment:
     //Also stash the actual proxy environment here.

--- a/EvalEngine/BlockEval.hpp
+++ b/EvalEngine/BlockEval.hpp
@@ -14,6 +14,7 @@
 #include <QStringList>
 #include <memory>
 #include <chrono>
+#include <Poco/Logger.h>
 
 class EnvironmentEval;
 class ThreadPoolEval;
@@ -215,4 +216,6 @@ private:
     Pothos::Proxy _blockEval;
     Pothos::Proxy _proxyBlock;
     bool _queryPortDesc;
+
+    Poco::Logger &_logger;
 };

--- a/EvalEngine/BlockEval.hpp
+++ b/EvalEngine/BlockEval.hpp
@@ -140,7 +140,7 @@ private:
     bool hasCriticalChange(void) const;
 
     //! any setters that changed so we can re-call them
-    std::vector<QJsonObject> settersChangedList(void) const;
+    QStringList settersChangedList(void) const;
 
     //! detect a change in properties before vs after
     bool didPropKeyHaveChange(const QString &key) const;

--- a/EvalEngine/EnvironmentEval.cpp
+++ b/EvalEngine/EnvironmentEval.cpp
@@ -73,8 +73,8 @@ HostProcPair EnvironmentEval::getHostProcFromConfig(const QString &zoneName, con
     if (zoneName == "gui") return HostProcPair(QString::fromStdString("gui://"+Pothos::Util::getLoopbackAddr()), "gui");
 
     const auto uriDefault = QString::fromStdString("tcp://"+Pothos::Util::getLoopbackAddr());
-    const auto hostUri = config.value("hostUri").toString(uriDefault);
-    const auto processName = config.value("processName").toString("");
+    const auto hostUri = config["hostUri"].toString(uriDefault);
+    const auto processName = config["processName"].toString("");
     return HostProcPair(hostUri, processName);
 }
 

--- a/EvalEngine/EnvironmentEval.cpp
+++ b/EvalEngine/EnvironmentEval.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "EnvironmentEval.hpp"
@@ -9,7 +9,6 @@
 #include <Poco/URI.h>
 #include <Poco/Net/SocketAddress.h>
 #include <Poco/Logger.h>
-#include <sstream>
 
 EnvironmentEval::EnvironmentEval(void):
     _failureState(false)
@@ -22,7 +21,7 @@ EnvironmentEval::~EnvironmentEval(void)
     return;
 }
 
-void EnvironmentEval::acceptConfig(const QString &zoneName, const Poco::JSON::Object::Ptr &config)
+void EnvironmentEval::acceptConfig(const QString &zoneName, const QJsonObject &config)
 {
     _zoneName = zoneName;
     _config = config;
@@ -58,23 +57,24 @@ void EnvironmentEval::update(void)
         const auto hostUri = getHostProcFromConfig(_zoneName, _config).first;
         try
         {
-            Pothos::RemoteClient client(hostUri);
+            Pothos::RemoteClient client(hostUri.toStdString());
             _errorMsg = tr("Remote environment %1 crashed").arg(_zoneName);
         }
         catch(const Pothos::RemoteClientError &)
         {
-            _errorMsg = tr("Remote host %1 is offline").arg(QString::fromStdString(hostUri));
+            _errorMsg = tr("Remote host %1 is offline").arg(hostUri);
         }
         poco_error_f2(Poco::Logger::get("PothosGui.EnvironmentEval.update"), "%s - %s", ex.displayText(), _errorMsg.toStdString());
     }
 }
 
-HostProcPair EnvironmentEval::getHostProcFromConfig(const QString &zoneName, const Poco::JSON::Object::Ptr &config)
+HostProcPair EnvironmentEval::getHostProcFromConfig(const QString &zoneName, const QJsonObject &config)
 {
-    if (zoneName == "gui") return HostProcPair("gui://"+Pothos::Util::getLoopbackAddr(), "gui");
+    if (zoneName == "gui") return HostProcPair(QString::fromStdString("gui://"+Pothos::Util::getLoopbackAddr()), "gui");
 
-    auto hostUri = config?config->getValue<std::string>("hostUri"):("tcp://"+Pothos::Util::getLoopbackAddr());
-    auto processName = config?config->getValue<std::string>("processName"):"";
+    const auto uriDefault = QString::fromStdString("tcp://"+Pothos::Util::getLoopbackAddr());
+    const auto hostUri = config.value("hostUri").toString(uriDefault);
+    const auto processName = config.value("processName").toString("");
     return HostProcPair(hostUri, processName);
 }
 
@@ -82,7 +82,7 @@ Pothos::ProxyEnvironment::Sptr EnvironmentEval::makeEnvironment(void)
 {
     if (_zoneName == "gui") return Pothos::ProxyEnvironment::make("managed");
 
-    const auto hostUri = getHostProcFromConfig(_zoneName, _config).first;
+    const auto hostUri = getHostProcFromConfig(_zoneName, _config).first.toStdString();
 
     //connect to the remote host and spawn a server
     auto serverEnv = Pothos::RemoteClient(hostUri).makeEnvironment("managed");

--- a/EvalEngine/EnvironmentEval.cpp
+++ b/EvalEngine/EnvironmentEval.cpp
@@ -8,10 +8,10 @@
 #include <Pothos/Util/Network.hpp>
 #include <Poco/URI.h>
 #include <Poco/Net/SocketAddress.h>
-#include <Poco/Logger.h>
 
 EnvironmentEval::EnvironmentEval(void):
-    _failureState(false)
+    _failureState(false),
+    _logger(Poco::Logger::get("PothosGui.EnvironmentEval"))
 {
     return;
 }
@@ -64,7 +64,7 @@ void EnvironmentEval::update(void)
         {
             _errorMsg = tr("Remote host %1 is offline").arg(hostUri);
         }
-        poco_error_f2(Poco::Logger::get("PothosGui.EnvironmentEval.update"), "%s - %s", ex.displayText(), _errorMsg.toStdString());
+        _logger.error("zone[%s]: %s - %s", _zoneName.toStdString(), ex.displayText(), _errorMsg.toStdString());
     }
 }
 
@@ -123,8 +123,7 @@ Pothos::ProxyEnvironment::Sptr EnvironmentEval::makeEnvironment(void)
         //otherwise warn because the forwarding will not work
         else
         {
-            poco_warning_f1(Poco::Logger::get("PothosGui.EnvironmentEval.make"),
-                "Log forwarding not supported over IPv6: %s", logSource);
+            _logger.warning("Log forwarding not supported over IPv6: %s", logSource);
             return env;
         }
     }

--- a/EvalEngine/EnvironmentEval.hpp
+++ b/EvalEngine/EnvironmentEval.hpp
@@ -9,6 +9,7 @@
 #include <QString>
 #include <memory>
 #include <utility>
+#include <Poco/Logger.h>
 
 typedef std::pair<QString, QString> HostProcPair;
 
@@ -68,4 +69,5 @@ private:
     Pothos::Proxy _eval;
     bool _failureState;
     QString _errorMsg;
+    Poco::Logger &_logger;
 };

--- a/EvalEngine/EnvironmentEval.hpp
+++ b/EvalEngine/EnvironmentEval.hpp
@@ -1,17 +1,16 @@
-// Copyright (c) 2014-2014 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
 #include <Pothos/Config.hpp>
 #include <Pothos/Proxy/Environment.hpp>
-#include <Poco/JSON/Object.h>
+#include <QJsonObject>
 #include <QObject>
 #include <QString>
 #include <memory>
-#include <string>
 #include <utility>
 
-typedef std::pair<std::string, std::string> HostProcPair;
+typedef std::pair<QString, QString> HostProcPair;
 
 class EnvironmentEval : public QObject
 {
@@ -26,7 +25,7 @@ public:
      * Called under re-eval to apply the latest config.
      * This call should take the info and not process.
      */
-    void acceptConfig(const QString &zoneName, const Poco::JSON::Object::Ptr &config);
+    void acceptConfig(const QString &zoneName, const QJsonObject &config);
 
     /*!
      * Deal with changes from the latest config.
@@ -34,7 +33,7 @@ public:
     void update(void);
 
     //! Shared method to parse the zone config into host uri and process name
-    static HostProcPair getHostProcFromConfig(const QString &zoneName, const Poco::JSON::Object::Ptr &config);
+    static HostProcPair getHostProcFromConfig(const QString &zoneName, const QJsonObject &config);
 
     //! Get access to the proxy environment
     Pothos::ProxyEnvironment::Sptr getEnv(void) const
@@ -64,7 +63,7 @@ private:
     Pothos::ProxyEnvironment::Sptr makeEnvironment(void);
 
     QString _zoneName;
-    Poco::JSON::Object::Ptr _config;
+    QJsonObject _config;
     Pothos::ProxyEnvironment::Sptr _env;
     Pothos::Proxy _eval;
     bool _failureState;

--- a/EvalEngine/EvalEngine.cpp
+++ b/EvalEngine/EvalEngine.cpp
@@ -146,7 +146,7 @@ void EvalEngine::handleEvalThreadHeartBeat(void)
     if (_flaggedLockUp)
     {
         _flaggedLockUp = false;
-        poco_notice(_logger, "Evaluation thread has recovered. Perhaps a call is taking too long.");
+        _logger.notice("Evaluation thread has recovered. Perhaps a call is taking too long.");
     }
 
     _lastHeartBeat = std::chrono::system_clock::now();
@@ -162,6 +162,6 @@ void EvalEngine::handleMonitorTimeout(void)
     {
         _flaggedLockUp = true;
         _monitorTimer->stop(); //stop so the error messages will not continue
-        poco_fatal(_logger, "Detected evaluation thread lock-up. The evaluator will not function.");
+        _logger.fatal("Detected evaluation thread lock-up. The evaluator will not function.");
     }
 }

--- a/EvalEngine/EvalEngine.cpp
+++ b/EvalEngine/EvalEngine.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "EvalEngine.hpp"
@@ -124,10 +124,10 @@ std::string EvalEngine::getTopologyJSONDump(const std::string &config)
     return result;
 }
 
-std::string EvalEngine::getTopologyJSONStats(void)
+QByteArray EvalEngine::getTopologyJSONStats(void)
 {
-    std::string result;
-    QMetaObject::invokeMethod(_impl, "getTopologyJSONStats", Qt::BlockingQueuedConnection, Q_RETURN_ARG(std::string, result));
+    QByteArray result;
+    QMetaObject::invokeMethod(_impl, "getTopologyJSONStats", Qt::BlockingQueuedConnection, Q_RETURN_ARG(QByteArray, result));
     return result;
 }
 

--- a/EvalEngine/EvalEngine.cpp
+++ b/EvalEngine/EvalEngine.cpp
@@ -110,17 +110,17 @@ void EvalEngine::submitBlock(QObject *obj)
     QMetaObject::invokeMethod(_impl, "submitBlock", Qt::QueuedConnection, Q_ARG(BlockInfo, blockToBlockInfo(block)));
 }
 
-std::string EvalEngine::getTopologyDotMarkup(const std::string &config)
+QByteArray EvalEngine::getTopologyDotMarkup(const QByteArray &config)
 {
-    std::string result;
-    QMetaObject::invokeMethod(_impl, "getTopologyDotMarkup", Qt::BlockingQueuedConnection, Q_RETURN_ARG(std::string, result), Q_ARG(std::string, config));
+    QByteArray result;
+    QMetaObject::invokeMethod(_impl, "getTopologyDotMarkup", Qt::BlockingQueuedConnection, Q_RETURN_ARG(QByteArray, result), Q_ARG(QByteArray, config));
     return result;
 }
 
-std::string EvalEngine::getTopologyJSONDump(const std::string &config)
+QByteArray EvalEngine::getTopologyJSONDump(const QByteArray &config)
 {
-    std::string result;
-    QMetaObject::invokeMethod(_impl, "getTopologyJSONDump", Qt::BlockingQueuedConnection, Q_RETURN_ARG(std::string, result), Q_ARG(std::string, config));
+    QByteArray result;
+    QMetaObject::invokeMethod(_impl, "getTopologyJSONDump", Qt::BlockingQueuedConnection, Q_RETURN_ARG(QByteArray, result), Q_ARG(QByteArray, config));
     return result;
 }
 

--- a/EvalEngine/EvalEngine.hpp
+++ b/EvalEngine/EvalEngine.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -61,7 +61,7 @@ public slots:
     std::string getTopologyJSONDump(const std::string &config);
 
     //! query the JSON stats for the active topology
-    std::string getTopologyJSONStats(void);
+    QByteArray getTopologyJSONStats(void);
 
 private slots:
     void handleAffinityZonesChanged(void);

--- a/EvalEngine/EvalEngine.hpp
+++ b/EvalEngine/EvalEngine.hpp
@@ -55,10 +55,10 @@ public slots:
     void submitBlock(QObject *block);
 
     //! query the dot markup for the active topology
-    std::string getTopologyDotMarkup(const std::string &config);
+    QByteArray getTopologyDotMarkup(const QByteArray &config);
 
     //! query the JSON dump for the active topology
-    std::string getTopologyJSONDump(const std::string &config);
+    QByteArray getTopologyJSONDump(const QByteArray &config);
 
     //! query the JSON stats for the active topology
     QByteArray getTopologyJSONStats(void);

--- a/EvalEngine/EvalEngineImpl.cpp
+++ b/EvalEngine/EvalEngineImpl.cpp
@@ -135,22 +135,26 @@ void EvalEngineImpl::submitZoneInfo(const ZoneInfos &info)
     this->evaluate();
 }
 
-std::string EvalEngineImpl::getTopologyDotMarkup(const std::string &config)
+QByteArray EvalEngineImpl::getTopologyDotMarkup(const QByteArray &configBytes)
 {
     //have to do this in case this call compressed an eval-worthy event
     this->evaluate();
 
-    if (not _topologyEval) return "";
-    return _topologyEval->getTopology()->toDotMarkup(config);
+    if (not _topologyEval) return QByteArray();
+    const std::string config(configBytes.data(), configBytes.size());
+    const auto markup = _topologyEval->getTopology()->toDotMarkup(config);
+    return QByteArray(markup.data(), markup.size());
 }
 
-std::string EvalEngineImpl::getTopologyJSONDump(const std::string &config)
+QByteArray EvalEngineImpl::getTopologyJSONDump(const QByteArray &configBytes)
 {
     //have to do this in case this call compressed an eval-worthy event
     this->evaluate();
 
-    if (not _topologyEval) return "";
-    return _topologyEval->getTopology()->dumpJSON(config);
+    if (not _topologyEval) return QByteArray();
+    const std::string config(configBytes.data(), configBytes.size());
+    const auto dump = _topologyEval->getTopology()->dumpJSON(config);
+    return QByteArray(dump.data(), dump.size());
 }
 
 QByteArray EvalEngineImpl::getTopologyJSONStats(void)

--- a/EvalEngine/EvalEngineImpl.cpp
+++ b/EvalEngine/EvalEngineImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "EvalEngineImpl.hpp"
@@ -153,13 +153,14 @@ std::string EvalEngineImpl::getTopologyJSONDump(const std::string &config)
     return _topologyEval->getTopology()->dumpJSON(config);
 }
 
-std::string EvalEngineImpl::getTopologyJSONStats(void)
+QByteArray EvalEngineImpl::getTopologyJSONStats(void)
 {
     //have to do this in case this call compressed an eval-worthy event
     this->evaluate();
 
-    if (not _topologyEval) return "";
-    return _topologyEval->getTopology()->queryJSONStats();
+    if (not _topologyEval) return QByteArray();
+    const auto stats = _topologyEval->getTopology()->queryJSONStats();
+    return QByteArray(stats.data(), stats.size());
 }
 
 void EvalEngineImpl::handleMonitorTimeout(void)

--- a/EvalEngine/EvalEngineImpl.cpp
+++ b/EvalEngine/EvalEngineImpl.cpp
@@ -196,7 +196,7 @@ void EvalEngineImpl::evaluate(void)
         const auto &zone = blockInfo.zone;
 
         //extract the configuration for this zone
-        Poco::JSON::Object::Ptr config;
+        QJsonObject config;
         {
             auto it = _zoneInfo.find(zone);
             if (it != _zoneInfo.end()) config = it->second;

--- a/EvalEngine/EvalEngineImpl.hpp
+++ b/EvalEngine/EvalEngineImpl.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2015 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -67,7 +67,7 @@ public slots:
     std::string getTopologyJSONDump(const std::string &config);
 
     //! query the JSON stats for the active topology
-    std::string getTopologyJSONStats(void);
+    QByteArray getTopologyJSONStats(void);
 
     //! Cleanup and shutdown prior to destruction
     void submitCleanup(void);

--- a/EvalEngine/EvalEngineImpl.hpp
+++ b/EvalEngine/EvalEngineImpl.hpp
@@ -61,10 +61,10 @@ public slots:
     void submitZoneInfo(const ZoneInfos &info);
 
     //! query the dot markup for the active topology
-    std::string getTopologyDotMarkup(const std::string &config);
+    QByteArray getTopologyDotMarkup(const QByteArray &config);
 
     //! query the JSON dump for the active topology
-    std::string getTopologyJSONDump(const std::string &config);
+    QByteArray getTopologyJSONDump(const QByteArray &config);
 
     //! query the JSON stats for the active topology
     QByteArray getTopologyJSONStats(void);

--- a/EvalEngine/EvalEngineImpl.hpp
+++ b/EvalEngine/EvalEngineImpl.hpp
@@ -7,7 +7,7 @@
 #include "TopologyEval.hpp"
 #include "BlockEval.hpp"
 #include <QString>
-#include <Poco/JSON/Object.h>
+#include <QJsonObject>
 #include <memory>
 #include <map>
 #include <set>
@@ -21,7 +21,7 @@ class QTimer;
 class EvalEngineGuiBlockDeleter;
 
 typedef std::map<size_t, BlockInfo> BlockInfos;
-typedef std::map<QString, Poco::JSON::Object::Ptr> ZoneInfos;
+typedef std::map<QString, QJsonObject> ZoneInfos;
 
 /*!
  * The EvalEngineImpl hold eval state and performs the actual work

--- a/EvalEngine/ThreadPoolEval.cpp
+++ b/EvalEngine/ThreadPoolEval.cpp
@@ -77,7 +77,8 @@ void ThreadPoolEval::update(void)
         }
         catch (const Pothos::Exception &ex)
         {
-            poco_error(Poco::Logger::get("PothosGui.ThreadPoolEval.update"), ex.displayText());
+            static auto &logger = Poco::Logger::get("PothosGui.ThreadPoolEval");
+            logger.error("Error updating: %s", ex.displayText());
             _errorMsg = QString::fromStdString(ex.displayText());
             _failureState = true;
         }

--- a/EvalEngine/ThreadPoolEval.hpp
+++ b/EvalEngine/ThreadPoolEval.hpp
@@ -1,11 +1,11 @@
-// Copyright (c) 2014-2014 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
 #include <Pothos/Config.hpp>
 #include <Pothos/Proxy/Proxy.hpp>
 #include <Pothos/Proxy/Environment.hpp>
-#include <Poco/JSON/Object.h>
+#include <QJsonObject>
 #include <QObject>
 #include <QString>
 #include <memory>
@@ -26,7 +26,7 @@ public:
      * Called under re-eval to apply the latest config.
      * This call should take the info and not process.
      */
-    void acceptConfig(const Poco::JSON::Object::Ptr &config);
+    void acceptConfig(const QJsonObject &config);
 
     /*!
      * Called under re-eval to apply the latest environment.
@@ -72,8 +72,8 @@ private:
 
     //Tracking state for the thread pool configuration.
     //A change in config merritts making a new thread pool.
-    Poco::JSON::Object::Ptr _newZoneConfig;
-    Poco::JSON::Object::Ptr _lastZoneConfig;
+    QJsonObject _newZoneConfig;
+    QJsonObject _lastZoneConfig;
 
     Pothos::Proxy _threadPool;
     bool _failureState;

--- a/EvalEngine/TopologyEval.cpp
+++ b/EvalEngine/TopologyEval.cpp
@@ -58,8 +58,8 @@ void TopologyEval::update(void)
         try
         {
             _topology->disconnect(
-                src->getProxyBlock(), conn.srcPort,
-                dst->getProxyBlock(), conn.dstPort);
+                src->getProxyBlock(), conn.srcPort.toStdString(),
+                dst->getProxyBlock(), conn.dstPort.toStdString());
             std::remove(_currentConnections.begin(), _currentConnections.end(), conn);
         }
         catch (const Pothos::Exception &ex)
@@ -91,8 +91,8 @@ void TopologyEval::update(void)
         try
         {
             _topology->connect(
-                src->getProxyBlock(), conn.srcPort,
-                dst->getProxyBlock(), conn.dstPort);
+                src->getProxyBlock(), conn.srcPort.toStdString(),
+                dst->getProxyBlock(), conn.dstPort.toStdString());
             std::remove(_currentConnections.begin(), _currentConnections.end(), conn);
             _currentConnections.push_back(conn);
         }

--- a/EvalEngine/TopologyEval.cpp
+++ b/EvalEngine/TopologyEval.cpp
@@ -4,12 +4,12 @@
 #include "TopologyEval.hpp"
 #include "BlockEval.hpp"
 #include <Pothos/Framework.hpp>
-#include <Poco/Logger.h>
 #include <algorithm> //std::remove
 
 TopologyEval::TopologyEval(void):
     _topology(new Pothos::Topology()),
-    _failureState(false)
+    _failureState(false),
+    _logger(Poco::Logger::get("PothosGui.TopologyEval"))
 {
     return;
 }
@@ -64,7 +64,7 @@ void TopologyEval::update(void)
         }
         catch (const Pothos::Exception &ex)
         {
-            poco_error(Poco::Logger::get("PothosGui.TopologyEval.disconnect"), ex.displayText());
+            _logger.error("Failed to disconnect: %s", ex.displayText());
             _failureState = true;
             return;
         }
@@ -98,7 +98,7 @@ void TopologyEval::update(void)
         }
         catch (const Pothos::Exception &ex)
         {
-            poco_error(Poco::Logger::get("PothosGui.TopologyEval.connect"), ex.displayText());
+            _logger.error("Failed to connect: %s", ex.displayText());
             _failureState = true;
             return;
         }
@@ -114,7 +114,7 @@ void TopologyEval::update(void)
     }
     catch (const Pothos::Exception &ex)
     {
-        poco_error(Poco::Logger::get("PothosGui.TopologyEval.commit"), ex.displayText());
+        _logger.error("Failed to commit: %s", ex.displayText());
         _failureState = true;
         return;
     }

--- a/EvalEngine/TopologyEval.hpp
+++ b/EvalEngine/TopologyEval.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include <memory>
 #include <map>
+#include <Poco/Logger.h>
 
 class BlockEval;
 
@@ -95,4 +96,5 @@ private:
     ConnectionInfos _currentConnections;
 
     bool _failureState;
+    Poco::Logger &_logger;
 };

--- a/EvalEngine/TopologyEval.hpp
+++ b/EvalEngine/TopologyEval.hpp
@@ -6,7 +6,7 @@
 #include "GraphObjects/GraphObject.hpp"
 #include <Pothos/Proxy/Proxy.hpp>
 #include <QObject>
-#include <string>
+#include <QString>
 #include <vector>
 #include <memory>
 #include <map>
@@ -29,7 +29,7 @@ struct ConnectionInfo
         srcBlockUID(0),
         dstBlockUID(0){}
     size_t srcBlockUID, dstBlockUID;
-    std::string srcPort, dstPort;
+    QString srcPort, dstPort;
 };
 
 bool operator==(const ConnectionInfo &lhs, const ConnectionInfo &rhs);

--- a/EvalEngine/TopologyTraversal.cpp
+++ b/EvalEngine/TopologyTraversal.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "TopologyEval.hpp"
@@ -88,9 +88,9 @@ ConnectionInfos TopologyEval::getConnectionInfo(const GraphObjectList &graphObje
             {
                 ConnectionInfo info;
                 info.srcBlockUID = outputEp.getObj()->uid();
-                info.srcPort = outputEp.getKey().id.toStdString();
+                info.srcPort = outputEp.getKey().id;
                 info.dstBlockUID = subEp.getObj()->uid();
-                info.dstPort = subEp.getKey().id.toStdString();
+                info.dstPort = subEp.getKey().id;
                 connections.push_back(info);
             }
         }

--- a/GraphEditor/GraphDraw.cpp
+++ b/GraphEditor/GraphDraw.cpp
@@ -9,7 +9,7 @@
 #include "PropertiesPanel/PropertiesPanelDock.hpp"
 #include "MainWindow/MainActions.hpp"
 #include "MainWindow/MainMenu.hpp"
-#include <Poco/JSON/Parser.h>
+#include <QJsonDocument>
 #include <QGraphicsScene>
 #include <QGraphicsPixmapItem>
 #include <QMenu>
@@ -94,8 +94,8 @@ void GraphDraw::handleGraphDebugViewChange(void)
 
 void GraphDraw::dragEnterEvent(QDragEnterEvent *event)
 {
-    if (event->mimeData()->hasFormat("text/json/pothos_block") and
-        not event->mimeData()->data("text/json/pothos_block").isEmpty())
+    if (event->mimeData()->hasFormat("binary/json/pothos_block") and
+        not event->mimeData()->data("binary/json/pothos_block").isEmpty())
     {
         event->acceptProposedAction();
     }
@@ -109,8 +109,8 @@ void GraphDraw::dragLeaveEvent(QDragLeaveEvent *event)
 
 void GraphDraw::dragMoveEvent(QDragMoveEvent *event)
 {
-    if (event->mimeData()->hasFormat("text/json/pothos_block") and
-        not event->mimeData()->data("text/json/pothos_block").isEmpty())
+    if (event->mimeData()->hasFormat("binary/json/pothos_block") and
+        not event->mimeData()->data("binary/json/pothos_block").isEmpty())
     {
         event->acceptProposedAction();
     }
@@ -119,10 +119,8 @@ void GraphDraw::dragMoveEvent(QDragMoveEvent *event)
 
 void GraphDraw::dropEvent(QDropEvent *event)
 {
-    const auto byteArray = event->mimeData()->data("text/json/pothos_block");
-    const auto result = Poco::JSON::Parser().parse(std::string(byteArray.constData(), byteArray.size()));
-    const auto blockDesc = result.extract<Poco::JSON::Object::Ptr>();
-
+    const auto byteArray = event->mimeData()->data("binary/json/pothos_block");
+    const auto blockDesc = QJsonDocument::fromBinaryData(byteArray).object();
     this->getGraphEditor()->handleAddBlock(blockDesc, this->mapToScene(event->pos()));
     event->acceptProposedAction();
 }

--- a/GraphEditor/GraphDrawSelection.cpp
+++ b/GraphEditor/GraphDrawSelection.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "GraphEditor/GraphDraw.hpp"
@@ -293,12 +293,13 @@ bool GraphDraw::tryToMakeConnection(const GraphConnectionEndpoint &thisEp)
         }
         catch (const Pothos::Exception &ex)
         {
-            poco_warning(Poco::Logger::get("PothosGui.GraphDraw.connect"), Poco::format("Cannot connect port %s[%s] to port %s[%s]: %s",
+            static auto &logger = Poco::Logger::get("PothosGui.GraphDraw");
+            logger.warning("Cannot connect port %s[%s] to port %s[%s]: %s",
                 _lastClickSelectEp.getObj()->getId().toStdString(),
                 _lastClickSelectEp.getKey().id.toStdString(),
                 thisEp.getObj()->getId().toStdString(),
                 thisEp.getKey().id.toStdString(),
-                ex.message()));
+                ex.message());
         }
 
         //cleanup regardless of failure

--- a/GraphEditor/GraphEditor.cpp
+++ b/GraphEditor/GraphEditor.cpp
@@ -29,13 +29,11 @@
 #include <QMimeData>
 #include <QRegExp>
 #include <QTimer>
-#include <fstream>
+#include <QUuid>
+#include <QFileInfo>
 #include <iostream>
 #include <cassert>
 #include <set>
-#include <Poco/Path.h>
-#include <Poco/UUID.h>
-#include <Poco/UUIDGenerator.h>
 #include <Pothos/Exception.hpp>
 #include <algorithm> //min/max
 
@@ -150,8 +148,7 @@ QString GraphEditor::newId(const QString &hint, const QStringList &blacklist) co
     QString idBase = hint;
     if (idBase.isEmpty())
     {
-        Poco::UUIDGenerator &generator = Poco::UUIDGenerator::defaultGenerator();
-        idBase = QString::fromStdString(generator.createRandom().toString());
+        idBase = QUuid::createUuid().toString();
     }
 
     //find a reasonable name and index
@@ -1032,8 +1029,7 @@ void GraphEditor::render(void)
     QString title = tr("untitled");
     if (not this->getCurrentFilePath().isEmpty())
     {
-        auto name = Poco::Path(this->getCurrentFilePath().toStdString()).getBaseName();
-        title = QString::fromStdString(name);
+        title = QFileInfo(this->getCurrentFilePath()).baseName();
     }
     if (this->hasUnsavedChanges()) title += "*";
 

--- a/GraphEditor/GraphEditor.cpp
+++ b/GraphEditor/GraphEditor.cpp
@@ -197,8 +197,8 @@ void GraphEditor::updateEnabledActions(void)
 
     //can we paste something from the clipboard?
     auto mimeData = QApplication::clipboard()->mimeData();
-    const bool canPaste = mimeData->hasFormat("text/json/pothos_object_array") and
-                      not mimeData->data("text/json/pothos_object_array").isEmpty();
+    const bool canPaste = mimeData->hasFormat("binary/json/pothos_object_array") and
+                      not mimeData->data("binary/json/pothos_object_array").isEmpty();
     actions->pasteAction->setEnabled(canPaste);
 
     //update window title

--- a/GraphEditor/GraphEditor.cpp
+++ b/GraphEditor/GraphEditor.cpp
@@ -538,21 +538,19 @@ void GraphEditor::handleCopy(void)
     if (not this->isVisible()) return;
     auto draw = this->getCurrentGraphDraw();
 
-    Poco::JSON::Array jsonObjs;
+    QJsonArray jsonObjs;
     for (auto obj : draw->getObjectsSelected())
     {
-        jsonObjs.add(obj->serialize());
+        jsonObjs.push_back(obj->serialize());
     }
 
     //to byte array
-    std::ostringstream oss;
-    jsonObjs.stringify(oss);
-    const std::string bytesStr(oss.str());
-    const QByteArray byteArray(bytesStr.data(), bytesStr.size());
+    const QJsonDocument jsonDoc(jsonObjs);
+    const auto data = jsonDoc.toBinaryData();
 
     //load the clipboard
     auto mimeData = new QMimeData();
-    mimeData->setData("binary/json/pothos_object_array", byteArray);
+    mimeData->setData("binary/json/pothos_object_array", data);
     QApplication::clipboard()->setMimeData(mimeData);
 }
 

--- a/GraphEditor/GraphEditor.hpp
+++ b/GraphEditor/GraphEditor.hpp
@@ -162,6 +162,8 @@ private:
     Poco::Logger &_logger;
     QTabWidget *_parentTabWidget;
 
+    void loadPages(const QJsonArray &pages, const QString &type);
+
     void updateGraphEditorMenus(void);
 
     void makeDefaultPage(void);

--- a/GraphEditor/GraphEditor.hpp
+++ b/GraphEditor/GraphEditor.hpp
@@ -1,15 +1,14 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
 #include <Pothos/Config.hpp>
 #include "GraphObjects/GraphObject.hpp"
 #include "GraphEditor/GraphState.hpp"
-#include <Poco/JSON/Object.h>
 #include <Poco/Logger.h>
+#include <QJsonObject>
 #include <QTabWidget>
 #include <QPointer>
-#include <ios>
 
 class GraphConnection;
 class GraphDraw;
@@ -31,9 +30,9 @@ public:
     //! Restore evaluator and from a plugin reload
     void restartEvaluation(void);
 
-    void dumpState(std::ostream &os) const;
+    QByteArray dumpState(void) const;
 
-    void loadState(std::istream &os);
+    void loadState(const QByteArray &data);
 
     /*!
      * Generate a new ID that is unique to the graph,
@@ -70,7 +69,7 @@ public:
         return not _stateManager->isCurrentSaved();
     }
 
-    void handleAddBlock(const Poco::JSON::Object::Ptr &, const QPointF &);
+    void handleAddBlock(const QJsonObject &, const QPointF &);
 
     //! force a re-rendering of the graph page
     void render(void);
@@ -122,7 +121,7 @@ private slots:
     void handleRenameGraphPage(void);
     void handleDeleteGraphPage(void);
     void handleMoveGraphObjects(const int index);
-    void handleAddBlock(const Poco::JSON::Object::Ptr &);
+    void handleAddBlock(const QJsonObject &);
     void handleCreateBreaker(const bool isInput);
     void handleCreateInputBreaker(void);
     void handleCreateOutputBreaker(void);

--- a/GraphEditor/GraphEditorDeserialization.cpp
+++ b/GraphEditor/GraphEditorDeserialization.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "GraphEditor/GraphEditor.hpp"
@@ -8,31 +8,31 @@
 #include "GraphObjects/GraphConnection.hpp"
 #include "GraphObjects/GraphWidget.hpp"
 #include <Pothos/Exception.hpp>
-#include <Poco/JSON/Parser.h>
-#include <Poco/JSON/Array.h>
-#include <Poco/JSON/Object.h>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
 #include <Poco/Logger.h>
 #include <cassert>
 
 /***********************************************************************
  * Per-type creation routine
  **********************************************************************/
-static void loadPages(GraphEditor *editor, Poco::JSON::Array::Ptr pages, const std::string &type)
+static void loadPages(GraphEditor *editor, const QJsonArray &pages, const QString &type)
 {
-    for (size_t pageNo = 0; pageNo < pages->size(); pageNo++)
+    for (int pageNo = 0; pageNo < pages.size(); pageNo++)
     {
-        auto pageObj = pages->getObject(pageNo);
-        auto graphObjects = pageObj->getArray("graphObjects");
+        const auto pageObj = pages.at(pageNo).toObject();
+        const auto graphObjects = pageObj["graphObjects"].toArray();
         auto parent = editor->widget(pageNo);
 
-        for (size_t objIndex = 0; objIndex < graphObjects->size(); objIndex++)
+        for (const auto &graphVal : graphObjects)
         {
             GraphObject *obj = nullptr;
             POTHOS_EXCEPTION_TRY
             {
-                const auto jGraphObj = graphObjects->getObject(objIndex);
-                if (not jGraphObj) continue;
-                const auto what = jGraphObj->getValue<std::string>("what");
+                const auto jGraphObj = graphVal.toObject();
+                if (jGraphObj.isEmpty()) continue;
+                const auto what = jGraphObj["what"].toString();
                 if (what != type) continue;
                 if (type == "Block") obj = new GraphBlock(parent);
                 if (type == "Breaker") obj = new GraphBreaker(parent);
@@ -52,38 +52,30 @@ static void loadPages(GraphEditor *editor, Poco::JSON::Array::Ptr pages, const s
 /***********************************************************************
  * Deserialization routine
  **********************************************************************/
-void GraphEditor::loadState(std::istream &is)
+void GraphEditor::loadState(const QByteArray &data)
 {
-    const auto result = Poco::JSON::Parser().parse(is);
+    QJsonParseError parseError;
+    const auto jsonDoc = QJsonDocument::fromJson(data, &parseError);
+    if (jsonDoc.isNull())
+    {
+        Poco::Logger::get("PothosGui.GraphEditor.loadState").error("Error parsing JSON: %s", parseError.errorString().toStdString());
+        return;
+    }
 
     //extract topObj, old style is page array only
-    Poco::JSON::Object::Ptr topObj;
-    if (result.type() == typeid(Poco::JSON::Array::Ptr))
-    {
-        topObj = new Poco::JSON::Object();
-        topObj->set("pages", result.extract<Poco::JSON::Array::Ptr>());
-    }
-    else
-    {
-        topObj = result.extract<Poco::JSON::Object::Ptr>();
-    }
+    QJsonObject topObj;
+    if (jsonDoc.isArray())  topObj["pages"] = jsonDoc.array();
+    else topObj = jsonDoc.object();
 
     //extract global variables
     this->clearGlobals();
-    auto globals = topObj->getArray("globals");
-    if (globals) for (size_t constNo = 0; constNo < globals->size(); constNo++)
+    for (const auto &globalVal : topObj["globals"].toArray())
     {
-        const auto globalObj = globals->getObject(constNo);
-        if (not globalObj->has("name")) continue;
-        if (not globalObj->has("value")) continue;
-        this->setGlobalExpression(
-            QString::fromStdString(globalObj->getValue<std::string>("name")),
-            QString::fromStdString(globalObj->getValue<std::string>("value")));
+        const auto globalObj = globalVal.toObject();
+        if (not globalObj.contains("name")) continue;
+        if (not globalObj.contains("value")) continue;
+        this->setGlobalExpression(globalObj["name"].toString(), globalObj["value"].toString());
     }
-
-    //extract pages
-    auto pages = topObj->getArray("pages");
-    assert(pages);
 
     ////////////////////////////////////////////////////////////////////
     // clear existing stuff
@@ -103,14 +95,13 @@ void GraphEditor::loadState(std::istream &is)
     ////////////////////////////////////////////////////////////////////
     // create pages
     ////////////////////////////////////////////////////////////////////
-    for (size_t pageNo = 0; pageNo < pages->size(); pageNo++)
+    const auto pages = topObj["pages"].toArray();
+    for (int pageNo = 0; pageNo < pages.size(); pageNo++)
     {
-        auto pageObj = pages->getObject(pageNo);
-        auto pageName = pageObj->getValue<std::string>("pageName");
-        auto graphObjects = pageObj->getArray("graphObjects");
-        auto page = new GraphDraw(this);
-        this->insertTab(int(pageNo), page, QString::fromStdString(pageName));
-        if (pageObj->getValue<bool>("selected")) this->setCurrentIndex(pageNo);
+        const auto pageObj = pages.at(pageNo).toObject();
+        const auto pageName = pageObj["pageName"].toString();
+        this->insertTab(pageNo, new GraphDraw(this), pageName);
+        if (pageObj["selected"].toBool(false)) this->setCurrentIndex(pageNo);
     }
 
     ////////////////////////////////////////////////////////////////////

--- a/GraphEditor/GraphEditorExport.cpp
+++ b/GraphEditor/GraphEditorExport.cpp
@@ -13,7 +13,7 @@
 
 void GraphEditor::exportToJSONTopology(const QString &fileName)
 {
-    poco_information_f1(_logger, "Exporting %s", fileName.toStdString());
+    _logger.information("Exporting %s", fileName.toStdString());
     QJsonObject topObj;
 
     //all graph objects excluding widgets which are not exported

--- a/GraphEditor/GraphEditorExport.cpp
+++ b/GraphEditor/GraphEditorExport.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2016 Josh Blum
+// Copyright (c) 2016-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "GraphEditor/GraphEditor.hpp"
@@ -6,37 +6,38 @@
 #include "GraphEditor/Constants.hpp"
 #include "EvalEngine/TopologyEval.hpp"
 #include "AffinitySupport/AffinityZonesDock.hpp"
-#include <Poco/JSON/Array.h>
-#include <Poco/JSON/Object.h>
-#include <fstream>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QFile>
 
 void GraphEditor::exportToJSONTopology(const QString &fileName)
 {
     poco_information_f1(_logger, "Exporting %s", fileName.toStdString());
-    Poco::JSON::Object topObj;
+    QJsonObject topObj;
 
     //all graph objects excluding widgets which are not exported
     //we will have to filter out graphical blocks as well
     const auto graphObjects = this->getGraphObjects(~GRAPH_WIDGET);
 
     //global variables
-    Poco::JSON::Array globals;
+    QJsonArray globals;
     for (const auto &name : this->listGlobals())
     {
         const auto &value = this->getGlobalExpression(name);
-        Poco::JSON::Object globalObj;
-        globalObj.set("name", name.toStdString());
-        globalObj.set("value", value.toStdString());
-        globals.add(globalObj);
+        QJsonObject globalObj;
+        globalObj["name"] = name;
+        globalObj["value"] = value;
+        globals.push_back(globalObj);
     }
-    if (globals.size() > 0) topObj.set("globals", globals);
+    if (not globals.isEmpty()) topObj["globals"] = globals;
 
     //thread pools (filled in by blocks loop)
-    Poco::JSON::Object threadPools;
+    QJsonObject threadPools;
     auto affinityZones = AffinityZonesDock::global();
 
     //blocks
-    Poco::JSON::Array blocks;
+    QJsonArray blocks;
     std::map<size_t, const GraphBlock*> uidToBlock;
     for (const auto *obj : graphObjects)
     {
@@ -46,53 +47,53 @@ void GraphEditor::exportToJSONTopology(const QString &fileName)
         uidToBlock[block->uid()] = block;
 
         //copy in the the id and path
-        Poco::JSON::Object blockObj;
-        blockObj.set("id", block->getId().toStdString());
-        blockObj.set("path", block->getBlockDescPath());
+        QJsonObject blockObj;
+        blockObj["id"] = block->getId();
+        blockObj["path"] = block->getBlockDescPath();
 
         //setup the thread pool when specified
         const auto affinityZone = block->getAffinityZone();
         if (not affinityZone.isEmpty() and affinityZone != "gui")
         {
             const auto config = affinityZones->zoneToConfig(affinityZone);
-            threadPools.set(affinityZone.toStdString(), config);
-            blockObj.set("threadPool", affinityZone.toStdString());
+            threadPools[affinityZone] = config;
+            blockObj["threadPool"] = affinityZone;
         }
 
         //block description args are in the same format
         const auto desc = block->getBlockDesc();
-        if (desc->has("args")) blockObj.set("args", desc->get("args"));
+        if (desc.contains("args")) blockObj["args"] = desc["args"];
 
         //copy in the named calls in array format
-        Poco::JSON::Array calls;
-        if (desc->isArray("calls")) for (const auto &elem : *desc->getArray("calls"))
+        QJsonArray calls;
+        for (const auto &callVal : desc["calls"].toArray())
         {
-            const auto callObj = elem.extract<Poco::JSON::Object::Ptr>();
-            Poco::JSON::Array call;
-            call.add(callObj->get("name"));
-            for (const auto &arg : *callObj->getArray("args")) call.add(arg);
-            calls.add(call);
+            const auto callObj = callVal.toObject();
+            QJsonArray call;
+            call.push_back(callObj["name"]);
+            for (const auto &arg : callObj["args"].toArray()) call.push_back(arg);
+            calls.push_back(call);
         }
-        blockObj.set("calls", calls);
+        blockObj["calls"] = calls;
 
         //copy in the parameters as local variables
-        Poco::JSON::Array locals;
+        QJsonArray locals;
         for (const auto &name : block->getProperties())
         {
-            Poco::JSON::Object local;
-            local.set("name", name.toStdString());
-            local.set("value", block->getPropertyValue(name).toStdString());
-            locals.add(local);
+            QJsonObject local;
+            local["name"] = name;
+            local["value"] = block->getPropertyValue(name);
+            locals.push_back(local);
         }
-        blockObj.set("locals", locals);
+        blockObj["locals"] = locals;
 
-        blocks.add(blockObj);
+        blocks.push_back(blockObj);
     }
-    topObj.set("blocks", blocks);
-    if (threadPools.size() > 0) topObj.set("threadPools", threadPools);
+    topObj["blocks"] = blocks;
+    if (not threadPools.isEmpty()) topObj["threadPools"] = threadPools;
 
     //connections
-    Poco::JSON::Array connections;
+    QJsonArray connections;
     for (const auto &connInfo : TopologyEval::getConnectionInfo(graphObjects))
     {
         //the block may have been filtered out
@@ -103,23 +104,23 @@ void GraphEditor::exportToJSONTopology(const QString &fileName)
         if (dstIt == uidToBlock.end()) continue;
 
         //create the connection information in order
-        Poco::JSON::Array connArr;
-        connArr.add(srcIt->second->getId().toStdString());
-        connArr.add(connInfo.srcPort);
-        connArr.add(dstIt->second->getId().toStdString());
-        connArr.add(connInfo.dstPort);
-        connections.add(connArr);
+        QJsonArray connArr;
+        connArr.push_back(srcIt->second->getId());
+        connArr.push_back(connInfo.srcPort);
+        connArr.push_back(dstIt->second->getId());
+        connArr.push_back(connInfo.dstPort);
+        connections.push_back(connArr);
     }
-    topObj.set("connections", connections);
+    topObj["connections"] = connections;
+
+    //export to byte array
+    const QJsonDocument jsonDoc(topObj);
+    const auto data = jsonDoc.toJson(QJsonDocument::Indented);
 
     //write to file
-    try
+    QFile jsonFile(fileName);
+    if (not jsonFile.open(QFile::WriteOnly) or jsonFile.write(data) == -1)
     {
-        std::ofstream outFile(fileName.toStdString().c_str());
-        topObj.stringify(outFile, 4/*indent*/);
-    }
-    catch (const std::exception &ex)
-    {
-        poco_error_f2(_logger, "Error exporting %s: %s", fileName, std::string(ex.what()));
+        _logger.error("Error exporting %s: %s", fileName.toStdString(), jsonFile.errorString().toStdString());
     }
 }

--- a/GraphEditor/GraphEditorRenderedDialog.cpp
+++ b/GraphEditor/GraphEditorRenderedDialog.cpp
@@ -4,13 +4,6 @@
 #include "GraphEditor/GraphEditor.hpp"
 #include "EvalEngine/EvalEngine.hpp"
 #include <Pothos/Framework/Topology.hpp>
-#include <Pothos/Exception.hpp>
-#include <Poco/Format.h>
-#include <Poco/Pipe.h>
-#include <Poco/PipeStream.h>
-#include <Poco/Process.h>
-#include <Poco/Environment.h>
-#include <Poco/TemporaryFile.h>
 #include <QComboBox>
 #include <QDialog>
 #include <QFile>
@@ -22,78 +15,10 @@
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QMessageBox>
-#include <QFuture>
-#include <QFutureWatcher>
-#include <QtConcurrent/QtConcurrent>
+#include <QJsonObject>
 #include <QJsonDocument>
-
-struct ImageResult
-{
-    QPixmap pixmap;
-    std::string errorMsg;
-};
-
-static ImageResult dotMarkupToImage(const QByteArray &markup)
-{
-    ImageResult result;
-    if (markup.isNull())
-    {
-        result.errorMsg = "no markup - is the topology active?";
-        return result;
-    }
-
-    //temp file
-    auto tempFile = Poco::TemporaryFile::tempName();
-    Poco::TemporaryFile::registerForDeletion(tempFile);
-
-    //create args
-    Poco::Process::Args args;
-    args.push_back("-Tpng"); //yes png
-    args.push_back("-o"); //output to file
-    args.push_back(tempFile);
-
-    //launch
-    Poco::Pipe inPipe, outPipe, errPipe;
-    Poco::Process::Env env;
-    Poco::ProcessHandle ph(Poco::Process::launch(
-        Poco::Environment::get("DOT_EXECUTABLE", "dot"),
-        args, &inPipe, &outPipe, &errPipe, env));
-
-    //write the markup into dot
-    inPipe.writeBytes(markup.data(), markup.size());
-    inPipe.close();
-    outPipe.close();
-
-    //check for errors
-    const int retCode = ph.wait();
-    if (retCode != 0 or not QFile(QString::fromStdString(tempFile)).exists())
-    {
-        Poco::PipeInputStream es(errPipe);
-        std::string errMsg; es >> errMsg;
-        if (errMsg.empty()) errMsg = "dot";
-        throw Poco::SystemException(Poco::format("%s - (%d)", errMsg, retCode));
-    }
-
-    //create the image from file
-    result.pixmap = QPixmap(QString::fromStdString(tempFile), "png");
-    return result;
-}
-
-static ImageResult dotMarkupToImageSafe(const QByteArray &markup)
-{
-    ImageResult result;
-    try
-    {
-        result = dotMarkupToImage(markup);
-    }
-    catch (const Poco::Exception &ex)
-    {
-        result.errorMsg = "Image generation failed!\n";
-        result.errorMsg += ex.displayText() + "\n";
-        result.errorMsg += "Is Graphviz installed?";
-    }
-    return result;
-}
+#include <QTemporaryFile>
+#include <QProcess>
 
 class RenderedGraphDialog : public QDialog
 {
@@ -105,7 +30,7 @@ public:
         _topLayout(new QVBoxLayout(this)),
         _modeOptions(new QComboBox(this)),
         _portOptions(new QComboBox(this)),
-        _watcher(new QFutureWatcher<ImageResult>(this)),
+        _process(new QProcess(this)),
         _currentView(nullptr)
     {
         //create layouts
@@ -130,7 +55,7 @@ public:
         //connect widget changed events
         connect(_modeOptions, SIGNAL(currentIndexChanged(int)), this, SLOT(handleChange(int)));
         connect(_portOptions, SIGNAL(currentIndexChanged(int)), this, SLOT(handleChange(int)));
-        connect(_watcher, SIGNAL(finished(void)), this, SLOT(handleWatcherDone(void)));
+        connect(_process, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(handleProcessDone(int, QProcess::ExitStatus)));
 
         //initialize
         QPixmap pixmap(parent->size());
@@ -145,23 +70,46 @@ private slots:
         QJsonObject configObj;
         configObj["mode"] = _modeOptions->itemData(_modeOptions->currentIndex()).toString();
         configObj["port"] = _portOptions->itemData(_portOptions->currentIndex()).toString();
-
         const auto markup = _evalEngine->getTopologyDotMarkup(QJsonDocument(configObj).toJson());
-        _watcher->setFuture(QtConcurrent::run(std::bind(&dotMarkupToImageSafe, markup)));
+
+        //create args
+        QStringList args;
+        args.push_back("-Tpng"); //yes png
+        args.push_back("-o"); //output to file
+        _tempFile.open();
+        args.push_back(_tempFile.fileName());
+
+        //launch
+        auto dotExe = qgetenv("DOT_EXECUTABLE");
+        if (dotExe.isNull()) dotExe = "dot";
+        _process->start(dotExe, args);
+        if (not _process->waitForStarted())
+        {
+            this->displayErrorMessage(tr("%1\nIs Graphviz installed?").arg(_process->errorString()));
+        }
+
+        //write the markup into dot
+        _process->write(markup);
+        _process->closeWriteChannel();
     }
 
-    void handleWatcherDone(void)
+    void handleProcessDone(int exitCode, QProcess::ExitStatus exitStatus)
     {
-        auto imageResult = _watcher->result();
-        if (imageResult.errorMsg.empty())
+        if (exitCode != 0 or exitStatus != QProcess::NormalExit)
         {
-            installNewView(imageResult.pixmap);
+            this->displayErrorMessage(_process->readAllStandardError());
         }
+
         else
         {
-            QMessageBox msgBox(QMessageBox::Critical, tr("Topology render error"), QString::fromStdString(imageResult.errorMsg));
-            msgBox.exec();
+            this->installNewView(QPixmap(_tempFile.fileName(), "png"));
         }
+    }
+
+    void displayErrorMessage(const QString &errorMsg)
+    {
+        QMessageBox msgBox(QMessageBox::Critical, tr("Topology render error"), tr("Image generation failed!\n%1").arg(errorMsg));
+        msgBox.exec();
     }
 
     void installNewView(const QPixmap &pixmap)
@@ -183,7 +131,8 @@ private:
     QVBoxLayout *_topLayout;
     QComboBox *_modeOptions;
     QComboBox *_portOptions;
-    QFutureWatcher<ImageResult> *_watcher;
+    QProcess *_process;
+    QTemporaryFile _tempFile;
     QWidget *_currentView;
 };
 

--- a/GraphEditor/GraphEditorTabs.cpp
+++ b/GraphEditor/GraphEditorTabs.cpp
@@ -297,7 +297,8 @@ void GraphEditorTabs::loadState(void)
         if (files.at(i).isEmpty()) continue; //skip empty files
         if (not QFile::exists(files.at(i)))
         {
-            poco_error_f1(Poco::Logger::get("PothosGui.GraphEditorTabs.loadState"), "File %s does not exist", files.at(i).toStdString());
+            static auto &logger = Poco::Logger::get("PothosGui.GraphEditorTabs");
+            logger.error("File %s does not exist", files.at(i).toStdString());
             continue;
         }
         auto editor = new GraphEditor(this);

--- a/GraphEditor/GraphEditorTabs.cpp
+++ b/GraphEditor/GraphEditorTabs.cpp
@@ -138,9 +138,9 @@ void GraphEditorTabs::handleSave(GraphEditor *editor)
 
 static QString defaultSavePath(void)
 {
-    const auto defaultPath = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation) + "/untitled.pothos";
+    const auto defaultPath = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
     assert(!defaultPath.isEmpty());
-    return QDir(defaultPath).absolutePath();
+    return QDir(defaultPath).absoluteFilePath("untitled.pothos");
 }
 
 void GraphEditorTabs::handleSaveAs(void)

--- a/GraphEditor/GraphEditorTopologyStats.cpp
+++ b/GraphEditor/GraphEditorTopologyStats.cpp
@@ -86,12 +86,12 @@ private slots:
             const auto topObj = result.object();
             for (const auto &name : topObj.keys())
             {
-                const auto dataObj = topObj.value(name).toObject();
+                const auto dataObj = topObj[name].toObject();
 
                 auto &item = _statsItems[name];
                 if (item == nullptr)
                 {
-                    const auto title = dataObj.value("blockName").toString();
+                    const auto title = dataObj["blockName"].toString();
                     item = new QTreeWidgetItem(QStringList(title));
                     _statsTree->addTopLevelItem(item);
                 }

--- a/GraphEditor/GraphEditorTopologyStats.cpp
+++ b/GraphEditor/GraphEditorTopologyStats.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2016 Josh Blum
+// Copyright (c) 2015-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "MainWindow/IconUtils.hpp"
@@ -16,9 +16,7 @@
 #include <QScrollArea>
 #include <QTreeWidget>
 #include <QtConcurrent/QtConcurrent>
-#include <Poco/JSON/Parser.h>
-#include <Poco/JSON/Array.h>
-#include <Poco/JSON/Object.h>
+#include <QJsonDocument>
 
 class TopologyStatsDialog : public QDialog
 {
@@ -34,7 +32,7 @@ public:
         _statsScroller(new QScrollArea(this)),
         _statsTree(new QTreeWidget(this)),
         _timer(new QTimer(this)),
-        _watcher(new QFutureWatcher<std::string>(this))
+        _watcher(new QFutureWatcher<QByteArray>(this))
     {
         //create layouts
         this->setWindowTitle(tr("Topology stats viewer"));
@@ -77,25 +75,24 @@ private slots:
     void handleWatcherDone(void)
     {
         const auto jsonStats = _watcher->result();
-        if (jsonStats.empty())
+        if (jsonStats.isNull())
         {
-            QMessageBox msgBox(QMessageBox::Critical, tr("Topology stats error"), tr("empty markup - is the topology active?"));
+            QMessageBox msgBox(QMessageBox::Critical, tr("Topology stats error"), tr("no stats - is the topology active?"));
             msgBox.exec();
         }
         else
         {
-            const auto result = Poco::JSON::Parser().parse(jsonStats);
-            auto topObj = result.extract<Poco::JSON::Object::Ptr>();
-            std::vector<std::string> names; topObj->getNames(names);
-            for (const auto &name : names)
+            const auto result = QJsonDocument::fromJson(jsonStats);
+            const auto topObj = result.object();
+            for (const auto &name : topObj.keys())
             {
-                const auto dataObj = topObj->getObject(name);
+                const auto dataObj = topObj.value(name).toObject();
 
                 auto &item = _statsItems[name];
                 if (item == nullptr)
                 {
-                    const auto title = dataObj->getValue<std::string>("blockName");
-                    item = new QTreeWidgetItem(QStringList(QString::fromStdString(title)));
+                    const auto title = dataObj.value("blockName").toString();
+                    item = new QTreeWidgetItem(QStringList(title));
                     _statsTree->addTopLevelItem(item);
                 }
 
@@ -111,8 +108,7 @@ private slots:
                     _statsTree->setItemWidget(subItem, 0, label);
                 }
 
-                std::stringstream ss; dataObj->stringify(ss, 4);
-                label->setText(QString::fromStdString(ss.str()).replace("\\/", "/"));
+                label->setText(QJsonDocument(dataObj).toJson(QJsonDocument::Indented));
             }
         }
     }
@@ -125,9 +121,9 @@ private:
     QScrollArea *_statsScroller;
     QTreeWidget *_statsTree;
     QTimer *_timer;
-    QFutureWatcher<std::string> *_watcher;
-    std::map<std::string, QTreeWidgetItem *> _statsItems;
-    std::map<std::string, QLabel *> _statsLabels;
+    QFutureWatcher<QByteArray> *_watcher;
+    std::map<QString, QTreeWidgetItem *> _statsItems;
+    std::map<QString, QLabel *> _statsLabels;
 };
 
 void GraphEditor::handleShowTopologyStatsDialog(void)

--- a/GraphObjects/GraphBlock.cpp
+++ b/GraphObjects/GraphBlock.cpp
@@ -20,7 +20,6 @@
 #include <iostream>
 #include <cassert>
 #include <algorithm> //min/max
-#include <Poco/Logger.h>
 
 GraphBlock::GraphBlock(QObject *parent):
     GraphObject(parent),
@@ -966,7 +965,7 @@ void GraphBlock::deserialize(const QJsonObject &obj)
             blockParams.push_back(paramObj);
         }
         blockDescFallback["params"] = blockParams;
-        Poco::Logger::get("PothosGui.GraphBlock.init").error("Cant find block factory with path: '%s'", path.toStdString());
+        _impl->logger.error("Cant find block factory with path: '%s'", path.toStdString());
         this->setBlockDesc(blockDescFallback);
     }
 

--- a/GraphObjects/GraphBlock.hpp
+++ b/GraphObjects/GraphBlock.hpp
@@ -8,6 +8,8 @@
 #include <QObject>
 #include <QString>
 #include <QPointF>
+#include <QJsonArray>
+#include <QJsonObject>
 #include <memory>
 #include <vector>
 
@@ -20,19 +22,19 @@ public:
     GraphBlock(QObject *parent);
 
     //! set the block description from JSON object
-    void setBlockDesc(const Poco::JSON::Object::Ptr &);
-    const Poco::JSON::Object::Ptr &getBlockDesc(void) const;
-    std::string getBlockDescPath(void) const;
+    void setBlockDesc(const QJsonObject &);
+    const QJsonObject &getBlockDesc(void) const;
+    QString getBlockDescPath(void) const;
 
     //! set the input ports description from JSON array
-    void setInputPortDesc(const Poco::JSON::Array::Ptr &);
+    void setInputPortDesc(const QJsonArray &);
 
     //! set the output ports description from JSON array
-    void setOutputPortDesc(const Poco::JSON::Array::Ptr &);
+    void setOutputPortDesc(const QJsonArray &);
 
     //! set the dynamically queried block description overlay
-    void setOverlayDesc(const Poco::JSON::Object::Ptr &);
-    const Poco::JSON::Object::Ptr &getOverlayDesc(void) const;
+    void setOverlayDesc(const QJsonObject &);
+    const QJsonObject &getOverlayDesc(void) const;
 
     //! Does this graph block represent a display widget
     bool isGraphWidget(void) const;
@@ -40,7 +42,7 @@ public:
     void setGraphWidget(QWidget *);
 
     void setTitle(const QString &title);
-    QString getTitle(void) const;
+    const QString &getTitle(void) const;
 
     QPainterPath shape(void) const;
 
@@ -58,7 +60,7 @@ public:
     const QStringList &getProperties(void) const;
 
     //! Get the param desc from the block description
-    Poco::JSON::Object::Ptr getParamDesc(const QString &key) const;
+    QJsonObject getParamDesc(const QString &key) const;
 
     QString getPropertyValue(const QString &key) const;
     void setPropertyValue(const QString &key, const QString &value);
@@ -81,13 +83,13 @@ public:
     const QString &getPropertyErrorMsg(const QString &key) const;
 
     //! Set a descriptive type string for this property
-    void setPropertyTypeStr(const QString &key, const std::string &type);
-    const std::string &getPropertyTypeStr(const QString &key) const;
+    void setPropertyTypeStr(const QString &key, const QString &type);
+    const QString &getPropertyTypeStr(const QString &key) const;
 
     bool getPropertyPreview(const QString &key) const;
     void setPropertyPreviewMode(const QString &key, const QString &value,
-        const Poco::JSON::Array::Ptr &args = Poco::JSON::Array::Ptr(),
-        const Poco::JSON::Object::Ptr &kwargs = Poco::JSON::Object::Ptr());
+        const QJsonArray &args = QJsonArray(),
+        const QJsonObject &kwargs = QJsonObject());
 
     void addInputPort(const QString &portKey, const QString &portAlias);
     const QStringList &getInputPorts(void) const;
@@ -104,28 +106,28 @@ public:
     const QStringList &getSignalPorts(void) const;
 
     //! Set a descriptive type string for input ports
-    void setInputPortTypeStr(const QString &key, const std::string &type);
-    const std::string &getInputPortTypeStr(const QString &key) const;
+    void setInputPortTypeStr(const QString &key, const QString &type);
+    const QString &getInputPortTypeStr(const QString &key) const;
 
     //! Set a descriptive type string for output ports
-    void setOutputPortTypeStr(const QString &key, const std::string &type);
-    const std::string &getOutputPortTypeStr(const QString &key) const;
+    void setOutputPortTypeStr(const QString &key, const QString &type);
+    const QString &getOutputPortTypeStr(const QString &key) const;
 
     std::vector<GraphConnectableKey> getConnectableKeys(void) const;
     GraphConnectableKey isPointingToConnectable(const QPointF &pos) const;
     GraphConnectableAttrs getConnectableAttrs(const GraphConnectableKey &key) const;
 
-    Poco::JSON::Object::Ptr serialize(void) const;
+    QJsonObject serialize(void) const;
 
-    virtual void deserialize(Poco::JSON::Object::Ptr obj);
+    virtual void deserialize(const QJsonObject &obj);
 
     //! affinity zone support
     const QString &getAffinityZone(void) const;
     void setAffinityZone(const QString &zone);
 
     //! get current edit tab (empty for no selection)
-    const std::string &getActiveEditTab(void) const;
-    void setActiveEditTab(const std::string &name);
+    const QString &getActiveEditTab(void) const;
+    void setActiveEditTab(const QString &name);
 
     //! Called by Connection to track active graph connections
     void registerEndpoint(const GraphConnectionEndpoint &ep);
@@ -140,7 +142,7 @@ signals:
     void triggerEvalEvent(void);
 
     //! Called when the overlay changes the param description
-    void paramDescChanged(const QString &key, const Poco::JSON::Object::Ptr &desc);
+    void paramDescChanged(const QString &key, const QJsonObject &desc);
 
 protected:
 

--- a/GraphObjects/GraphBlockImpl.hpp
+++ b/GraphObjects/GraphBlockImpl.hpp
@@ -11,10 +11,12 @@
 #include <QStaticText>
 #include <vector>
 #include <map>
+#include <Poco/Logger.h>
 
 struct GraphBlock::Impl
 {
     Impl(void):
+        logger(Poco::Logger::get("PothosGui.GraphBlock")),
         isGraphWidget(false),
         signalPortUseCount(0),
         slotPortUseCount(0),
@@ -24,6 +26,7 @@ struct GraphBlock::Impl
         return;
     }
 
+    Poco::Logger &logger;
     bool isGraphWidget;
     QJsonObject blockDesc;
     QJsonObject overlayDesc;

--- a/GraphObjects/GraphBlockImpl.hpp
+++ b/GraphObjects/GraphBlockImpl.hpp
@@ -23,12 +23,12 @@ struct GraphBlock::Impl
         return;
     }
 
-    Poco::JSON::Object::Ptr blockDesc;
-    Poco::JSON::Object::Ptr overlayDesc;
-    Poco::JSON::Array::Ptr inputDesc;
-    Poco::JSON::Array::Ptr outputDesc;
+    QJsonObject blockDesc;
+    QJsonObject overlayDesc;
+    QJsonArray inputDesc;
+    QJsonArray outputDesc;
     QString affinityZone;
-    std::string activeEditTab;
+    QString activeEditTab;
 
     QStringList blockErrorMsgs;
 
@@ -41,10 +41,10 @@ struct GraphBlock::Impl
     std::map<QString, QString> propertiesNames;
     std::map<QString, QString> propertiesEditMode;
     std::map<QString, QString> propertiesPreview;
-    std::map<QString, Poco::JSON::Array::Ptr> propertiesPreviewArgs;
-    std::map<QString, Poco::JSON::Object::Ptr> propertiesPreviewKwargs;
+    std::map<QString, QJsonArray> propertiesPreviewArgs;
+    std::map<QString, QJsonObject> propertiesPreviewKwargs;
     std::map<QString, QString> propertiesErrorMsg;
-    std::map<QString, std::string> propertiesTypeStr;
+    std::map<QString, QString> propertiesTypeStr;
 
     std::map<QString, QString> inputPortsAliases;
     std::vector<QStaticText> inputPortsText;
@@ -52,7 +52,7 @@ struct GraphBlock::Impl
     std::vector<QRectF> inputPortRects;
     std::vector<QPointF> inputPortPoints;
     std::vector<QColor> inputPortColors;
-    std::map<QString, std::string> inputPortTypeStr;
+    std::map<QString, QString> inputPortTypeStr;
     std::map<QString, size_t> inputPortUseCount;
 
     std::map<QString, QString> outputPortsAliases;
@@ -61,7 +61,7 @@ struct GraphBlock::Impl
     std::vector<QRectF> outputPortRects;
     std::vector<QPointF> outputPortPoints;
     std::vector<QColor> outputPortColors;
-    std::map<QString, std::string> outputPortTypeStr;
+    std::map<QString, QString> outputPortTypeStr;
     std::map<QString, size_t> outputPortUseCount;
 
     QRectF signalPortRect;

--- a/GraphObjects/GraphBlockImpl.hpp
+++ b/GraphObjects/GraphBlockImpl.hpp
@@ -15,6 +15,7 @@
 struct GraphBlock::Impl
 {
     Impl(void):
+        isGraphWidget(false),
         signalPortUseCount(0),
         slotPortUseCount(0),
         showPortNames(false),
@@ -23,6 +24,7 @@ struct GraphBlock::Impl
         return;
     }
 
+    bool isGraphWidget;
     QJsonObject blockDesc;
     QJsonObject overlayDesc;
     QJsonArray inputDesc;

--- a/GraphObjects/GraphBlockUpdate.cpp
+++ b/GraphObjects/GraphBlockUpdate.cpp
@@ -4,7 +4,6 @@
 #include "GraphObjects/GraphBlockImpl.hpp"
 #include <QWidget>
 #include <Pothos/Proxy.hpp>
-#include <Poco/Logger.h>
 
 /***********************************************************************
  * initialize the block's properties
@@ -17,7 +16,7 @@ void GraphBlock::setBlockDesc(const QJsonObject &blockDesc)
     //extract the name or title from the description
     if (not blockDesc.contains("name"))
     {
-        poco_error(Poco::Logger::get("PothosGui.GraphBlock.init"), "Block missing 'name'");
+        _impl->logger.error("Block '%s' missing 'name'", this->getBlockDescPath().toStdString());
         return;
     }
     this->setTitle(blockDesc["name"].toString());
@@ -32,7 +31,7 @@ void GraphBlock::setBlockDesc(const QJsonObject &blockDesc)
         const auto param = paramValue.toObject();
         if (not param.contains("key"))
         {
-            Poco::Logger::get("PothosGui.GraphBlock.init").error("Block '%s' param missing 'key'", this->getTitle().toStdString());
+            _impl->logger.error("Block '%s' param missing 'key'", this->getTitle().toStdString());
             return;
         }
         const auto key = param["key"].toString();
@@ -49,7 +48,7 @@ void GraphBlock::setBlockDesc(const QJsonObject &blockDesc)
             auto opt0 = param["options"].toArray().at(0).toObject();
             if (not opt0.contains("value"))
             {
-                Poco::Logger::get("PothosGui.GraphBlock.init").warning("Block '%s' [param %s] missing 'value'", this->getTitle().toStdString(), name.toStdString());
+                _impl->logger.warning("Block '%s' [param %s] missing 'value'", this->getTitle().toStdString(), name.toStdString());
             }
             else this->setPropertyValue(key, opt0["value"].toString());
         }

--- a/GraphObjects/GraphBlockUpdate.cpp
+++ b/GraphObjects/GraphBlockUpdate.cpp
@@ -21,6 +21,7 @@ void GraphBlock::setBlockDesc(const QJsonObject &blockDesc)
         return;
     }
     this->setTitle(blockDesc["name"].toString());
+    _impl->isGraphWidget = (blockDesc["mode"].toString() == "graphWidget");
 
     //reload properties description, clear the old first
     _properties.clear();
@@ -35,7 +36,7 @@ void GraphBlock::setBlockDesc(const QJsonObject &blockDesc)
             return;
         }
         const auto key = param["key"].toString();
-        const auto name = param["name"].toString();
+        const auto name = param["name"].toString(key);
         this->addProperty(key);
         this->setPropertyName(key, name);
 

--- a/GraphObjects/GraphBlockUpdate.cpp
+++ b/GraphObjects/GraphBlockUpdate.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "GraphObjects/GraphBlockImpl.hpp"
@@ -9,66 +9,54 @@
 /***********************************************************************
  * initialize the block's properties
  **********************************************************************/
-void GraphBlock::setBlockDesc(const Poco::JSON::Object::Ptr &blockDesc)
+void GraphBlock::setBlockDesc(const QJsonObject &blockDesc)
 {
-    assert(blockDesc);
     if (_impl->blockDesc == blockDesc) return;
     _impl->blockDesc = blockDesc;
 
     //extract the name or title from the description
-    const auto name = blockDesc->getValue<std::string>("name");
-    if (not blockDesc->has("name"))
+    if (not blockDesc.contains("name"))
     {
         poco_error(Poco::Logger::get("PothosGui.GraphBlock.init"), "Block missing 'name'");
         return;
     }
-    this->setTitle(QString::fromStdString(name));
+    this->setTitle(blockDesc["name"].toString());
 
     //reload properties description, clear the old first
     _properties.clear();
 
     //extract the params or properties from the description
-    if (blockDesc->isArray("params")) for (const auto &paramObj : *blockDesc->getArray("params"))
+    for (const auto &paramValue : blockDesc["params"].toArray())
     {
-        const auto param = paramObj.extract<Poco::JSON::Object::Ptr>();
-        if (not param->has("key"))
+        const auto param = paramValue.toObject();
+        if (not param.contains("key"))
         {
-            poco_error_f1(Poco::Logger::get("PothosGui.GraphBlock.init"), "Block '%s' param missing 'key'", name);
+            Poco::Logger::get("PothosGui.GraphBlock.init").error("Block '%s' param missing 'key'", this->getTitle().toStdString());
             return;
         }
-        const auto key = QString::fromStdString(param->getValue<std::string>("key"));
-        const auto name = QString::fromStdString(param->optValue<std::string>("name", key.toStdString()));
+        const auto key = param["key"].toString();
+        const auto name = param["name"].toString();
         this->addProperty(key);
         this->setPropertyName(key, name);
 
-        if (param->has("default"))
+        if (param.contains("default"))
         {
-            this->setPropertyValue(key, QString::fromStdString(
-                param->getValue<std::string>("default")));
+            this->setPropertyValue(key, param["default"].toString());
         }
-        else if (param->isArray("options") and param->getArray("options")->size() > 0)
+        else if (not param["options"].toArray().isEmpty())
         {
-            auto opt0 = param->getArray("options")->getObject(0);
-            if (not opt0->has("value"))
+            auto opt0 = param["options"].toArray().at(0).toObject();
+            if (not opt0.contains("value"))
             {
-                poco_warning_f2(Poco::Logger::get("PothosGui.GraphBlock.init"), "Block '%s' [param %s] missing 'value'", name, name.toStdString());
+                Poco::Logger::get("PothosGui.GraphBlock.init").warning("Block '%s' [param %s] missing 'value'", this->getTitle().toStdString(), name.toStdString());
             }
-            else this->setPropertyValue(key, QString::fromStdString(opt0->getValue<std::string>("value")));
+            else this->setPropertyValue(key, opt0["value"].toString());
         }
 
-        if (param->has("preview"))
+        if (param.contains("preview"))
         {
-            const auto prevMode = param->getValue<std::string>("preview");
-
-            Poco::JSON::Array::Ptr args;
-            if (param->has("previewArgs") and param->isArray("previewArgs"))
-                args = param->getArray("previewArgs");
-
-            Poco::JSON::Object::Ptr kwargs;
-            if (param->has("previewKwargs") and param->isObject("previewKwargs"))
-                kwargs = param->getObject("previewKwargs");
-
-            this->setPropertyPreviewMode(key, QString::fromStdString(prevMode), args, kwargs);
+            this->setPropertyPreviewMode(key, param["preview"].toString(),
+                param["previewArgs"].toArray(), param["previewKwargs"].toObject());
         }
     }
 }
@@ -76,9 +64,8 @@ void GraphBlock::setBlockDesc(const Poco::JSON::Object::Ptr &blockDesc)
 /***********************************************************************
  * initialize the block's input ports
  **********************************************************************/
-void GraphBlock::setInputPortDesc(const Poco::JSON::Array::Ptr &inputDesc)
+void GraphBlock::setInputPortDesc(const QJsonArray &inputDesc)
 {
-    if (not inputDesc) return;
     if (_impl->inputDesc == inputDesc) return;
     _impl->inputDesc = inputDesc;
 
@@ -87,24 +74,22 @@ void GraphBlock::setInputPortDesc(const Poco::JSON::Array::Ptr &inputDesc)
     _slotPorts.clear();
 
     //reload inputs (and slots)
-    for (const auto &inputPortDesc : *inputDesc)
+    for (const auto &inputPortDesc : inputDesc)
     {
-        const auto &info = inputPortDesc.extract<Poco::JSON::Object::Ptr>();
-        auto portKey = QString::fromStdString(info->getValue<std::string>("name"));
-        QString portAlias = portKey;
-        if (info->has("alias")) portAlias = QString::fromStdString(info->getValue<std::string>("alias"));
-        if (info->has("isSigSlot") and info->getValue<bool>("isSigSlot")) this->addSlotPort(portKey);
+        const auto &info = inputPortDesc.toObject();
+        auto portKey = info["name"].toString();
+        const auto portAlias = info["alias"].toString(portKey);
+        if (info["isSigSlot"].toBool(false)) this->addSlotPort(portKey);
         else this->addInputPort(portKey, portAlias);
-        if (info->has("dtype")) this->setInputPortTypeStr(portKey, info->getValue<std::string>("dtype"));
+        if (info.contains("dtype")) this->setInputPortTypeStr(portKey, info["dtype"].toString());
     }
 }
 
 /***********************************************************************
  * initialize the block's output ports
  **********************************************************************/
-void GraphBlock::setOutputPortDesc(const Poco::JSON::Array::Ptr &outputDesc)
+void GraphBlock::setOutputPortDesc(const QJsonArray &outputDesc)
 {
-    if (not outputDesc) return;
     if (_impl->outputDesc == outputDesc) return;
     _impl->outputDesc = outputDesc;
 
@@ -113,14 +98,13 @@ void GraphBlock::setOutputPortDesc(const Poco::JSON::Array::Ptr &outputDesc)
     _signalPorts.clear();
 
     //reload outputs (and signals)
-    for (const auto &outputPortDesc : *outputDesc)
+    for (const auto &outputPortDesc : outputDesc)
     {
-        const auto &info = outputPortDesc.extract<Poco::JSON::Object::Ptr>();
-        auto portKey = QString::fromStdString(info->getValue<std::string>("name"));
-        QString portAlias = portKey;
-        if (info->has("alias")) portAlias = QString::fromStdString(info->getValue<std::string>("alias"));
-        if (info->has("isSigSlot") and info->getValue<bool>("isSigSlot")) this->addSignalPort(portKey);
+        const auto &info = outputPortDesc.toObject();
+        auto portKey = info["name"].toString();
+        const auto portAlias = info["alias"].toString(portKey);
+        if (info["isSigSlot"].toBool(false)) this->addSignalPort(portKey);
         else this->addOutputPort(portKey, portAlias);
-        if (info->has("dtype")) this->setOutputPortTypeStr(portKey, info->getValue<std::string>("dtype"));
+        if (info.contains("dtype")) this->setOutputPortTypeStr(portKey, info["dtype"].toString());
     }
 }

--- a/GraphObjects/GraphBreaker.cpp
+++ b/GraphObjects/GraphBreaker.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "GraphObjects/GraphBreaker.hpp"
@@ -186,22 +186,19 @@ void GraphBreaker::render(QPainter &painter)
     _impl->connectPoint = trans.map(connectionPoint);
 }
 
-Poco::JSON::Object::Ptr GraphBreaker::serialize(void) const
+QJsonObject GraphBreaker::serialize(void) const
 {
     auto obj = GraphObject::serialize();
-    obj->set("what", std::string("Breaker"));
-    obj->set("nodeName", this->getNodeName().toStdString());
-    obj->set("isInput", this->isInput());
+    obj["what"] = "Breaker";
+    obj["nodeName"] = this->getNodeName();
+    obj["isInput"] = this->isInput();
     return obj;
 }
 
-void GraphBreaker::deserialize(Poco::JSON::Object::Ptr obj)
+void GraphBreaker::deserialize(const QJsonObject &obj)
 {
-    auto nodeName = QString::fromStdString(obj->getValue<std::string>("nodeName"));
-    auto isInput = obj->getValue<bool>("isInput");
-
-    this->setInput(isInput);
-    this->setNodeName(nodeName);
+    this->setInput(obj["isInput"].toBool());
+    this->setNodeName(obj["nodeName"].toString());
 
     GraphObject::deserialize(obj);
 }

--- a/GraphObjects/GraphBreaker.hpp
+++ b/GraphObjects/GraphBreaker.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -40,9 +40,9 @@ public:
     GraphConnectableKey isPointingToConnectable(const QPointF &pos) const;
     GraphConnectableAttrs getConnectableAttrs(const GraphConnectableKey &key) const;
 
-    Poco::JSON::Object::Ptr serialize(void) const;
+    QJsonObject serialize(void) const;
 
-    virtual void deserialize(Poco::JSON::Object::Ptr obj);
+    virtual void deserialize(const QJsonObject &obj);
 
 private:
     void renderStaticText(void);

--- a/GraphObjects/GraphConnection.cpp
+++ b/GraphObjects/GraphConnection.cpp
@@ -126,8 +126,10 @@ void GraphConnection::setSigSlotPairs(const std::vector<SigSlotPair> &pairs)
 
 static void doSigSlotWarning(const QString &name, const GraphConnectionEndpoint &ep)
 {
-    poco_warning_f3(Poco::Logger::get("PothosGui.GraphConnection.addSigSlotPair"),
-        "cant find %s '%s' in %s", directionToStr(ep.getConnectableAttrs().direction).toStdString(), name.toStdString(), ep.getObj()->getId().toStdString());
+    static auto &logger = Poco::Logger::get("PothosGui.GraphConnection");
+    logger.warning("cant find %s '%s' in %s when connecting signal/slot pair",
+        directionToStr(ep.getConnectableAttrs().direction).toStdString(),
+        name.toStdString(), ep.getObj()->getId().toStdString());
 }
 
 void GraphConnection::addSigSlotPair(const SigSlotPair &sigSlot)

--- a/GraphObjects/GraphConnection.hpp
+++ b/GraphObjects/GraphConnection.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -55,9 +55,9 @@ public:
 
     void render(QPainter &painter);
 
-    Poco::JSON::Object::Ptr serialize(void) const;
+    QJsonObject serialize(void) const;
 
-    virtual void deserialize(Poco::JSON::Object::Ptr obj);
+    virtual void deserialize(const QJsonObject &obj);
 
 private slots:
 

--- a/GraphObjects/GraphEndpoint.hpp
+++ b/GraphObjects/GraphEndpoint.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -6,7 +6,7 @@
 #include <QPointer>
 #include <QString>
 #include <QPointF>
-#include <functional> //std::hash
+#include <QHash>
 
 class GraphObject;
 
@@ -56,8 +56,7 @@ namespace std
 
         value_type operator()(argument_type const& s) const
         {
-            return std::hash<std::string>()(s.id.toStdString()) ^
-            (std::hash<int>()(s.direction) << 1);
+            return qHash(s.id) ^ (qHash(s.direction) << 1);
         }
     };
 }

--- a/GraphObjects/GraphObject.cpp
+++ b/GraphObjects/GraphObject.cpp
@@ -232,25 +232,25 @@ const GraphConnectableKey &GraphObject::currentTrackedConnectable(void) const
     return _impl->trackedKey;
 }
 
-Poco::JSON::Object::Ptr GraphObject::serialize(void) const
+QJsonObject GraphObject::serialize(void) const
 {
-    Poco::JSON::Object::Ptr obj(new Poco::JSON::Object());
-    obj->set("id", this->getId().toStdString());
-    obj->set("zValue", double(this->zValue()));
-    obj->set("positionX", double(this->pos().x()));
-    obj->set("positionY", double(this->pos().y()));
-    obj->set("rotation", double(this->rotation()));
-    obj->set("selected", this->isSelected());
-    obj->set("enabled", this->isEnabled());
+    QJsonObject obj;
+    obj["id"] = this->getId();
+    obj["zValue"] = this->zValue();
+    obj["positionX"] = this->pos().x();
+    obj["positionY"] = this->pos().y();
+    obj["rotation"] = this->rotation();
+    obj["selected"] = this->isSelected();
+    obj["enabled"] = this->isEnabled();
     return obj;
 }
 
-void GraphObject::deserialize(Poco::JSON::Object::Ptr obj)
+void GraphObject::deserialize(const QJsonObject &obj)
 {
-    this->setId(QString::fromStdString(obj->getValue<std::string>("id")));
-    this->setZValue(obj->optValue<double>("zValue", 0.0));
-    this->setPos(QPointF(obj->optValue<double>("positionX", 0.0), obj->optValue<double>("positionY", 0.0)));
-    this->setRotation(obj->optValue<double>("rotation", 0.0));
-    this->setSelected(obj->optValue<bool>("selected", false));
-    this->setEnabled(obj->optValue<bool>("enabled", true));
+    this->setId(obj["id"].toString());
+    this->setZValue(obj["zValue"].toDouble(0.0));
+    this->setPos(QPointF(obj["positionX"].toDouble(0.0), obj["positionY"].toDouble(0.0)));
+    this->setRotation(obj["rotation"].toDouble(0.0));
+    this->setSelected(obj["selected"].toBool(false));
+    this->setEnabled(obj["enabled"].toBool(true));
 }

--- a/GraphObjects/GraphObject.cpp
+++ b/GraphObjects/GraphObject.cpp
@@ -7,22 +7,17 @@
 #include <QGraphicsSceneMouseEvent>
 #include <QGraphicsView>
 #include <QPainter>
-#include <Poco/SingletonHolder.h>
 #include <cassert>
 #include <atomic>
 #include <iostream>
 
-static std::atomic<size_t> &getUIDAtomic(void)
-{
-    static Poco::SingletonHolder<std::atomic<size_t>> sh;
-    return *sh.get();
-}
+Q_GLOBAL_STATIC(std::atomic<size_t>, getUIDAtomic)
 
 struct GraphObject::Impl
 {
     Impl(void):
         deleteFlag(false),
-        uid(getUIDAtomic()++),
+        uid((*getUIDAtomic())++),
         enabled(true),
         changed(true)
     {

--- a/GraphObjects/GraphObject.hpp
+++ b/GraphObjects/GraphObject.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -8,10 +8,9 @@
 #include <QGraphicsObject>
 #include <QPointF>
 #include <QRectF>
+#include <QJsonObject>
 #include <vector>
 #include <memory>
-#include <Poco/JSON/Array.h>
-#include <Poco/JSON/Object.h>
 
 class QObject;
 class QPainter;
@@ -77,9 +76,9 @@ public:
     bool isFlaggedForDelete(void) const;
     void flagForDelete(void);
 
-    virtual Poco::JSON::Object::Ptr serialize(void) const;
+    virtual QJsonObject serialize(void) const;
 
-    virtual void deserialize(Poco::JSON::Object::Ptr obj);
+    virtual void deserialize(const QJsonObject &obj);
 
 signals:
     void IDChanged(const QString &);

--- a/GraphObjects/GraphWidget.hpp
+++ b/GraphObjects/GraphWidget.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -30,9 +30,9 @@ public:
 
     QPainterPath shape(void) const;
 
-    Poco::JSON::Object::Ptr serialize(void) const;
+    QJsonObject serialize(void) const;
 
-    virtual void deserialize(Poco::JSON::Object::Ptr obj);
+    virtual void deserialize(const QJsonObject &obj);
 
     /*!
      * Get the saved state of the internal widget.

--- a/HostExplorer/HostSelectionTable.cpp
+++ b/HostExplorer/HostSelectionTable.cpp
@@ -18,7 +18,6 @@
 #include <Pothos/System.hpp>
 #include <Pothos/Util/Network.hpp>
 #include <Poco/DateTimeFormatter.h>
-#include <Poco/SingletonHolder.h>
 #include <map>
 #include <iostream>
 #include <functional> //std::bind

--- a/HostExplorer/HostSelectionTable.cpp
+++ b/HostExplorer/HostSelectionTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "MainWindow/IconUtils.hpp"
@@ -17,7 +17,6 @@
 #include <Pothos/Proxy.hpp>
 #include <Pothos/System.hpp>
 #include <Pothos/Util/Network.hpp>
-#include <Poco/DateTimeFormatter.h>
 #include <map>
 #include <iostream>
 #include <functional> //std::bind
@@ -40,8 +39,8 @@ void NodeInfo::update(void)
             settings->setValue("HostExplorer/"+this->uri+"/nodeName", this->nodeName);
         }
         this->isOnline = true;
-        this->lastAccess = Poco::Timestamp();
-        settings->setValue("HostExplorer/"+this->uri+"/lastAccess", int(this->lastAccess.epochTime()));
+        this->lastAccess = QDateTime::currentDateTime();
+        settings->setValue("HostExplorer/"+this->uri+"/lastAccess", this->lastAccess);
     }
     //otherwise, fetch the information from the settings cache
     catch(const Pothos::RemoteClientError &)
@@ -51,7 +50,7 @@ void NodeInfo::update(void)
         {
             this->nodeName = settings->value("HostExplorer/"+this->uri+"/nodeName").toString();
         }
-        this->lastAccess = Poco::Timestamp::fromEpochTime(std::time_t(settings->value("HostExplorer/"+this->uri+"/lastAccess").toInt()));
+        this->lastAccess = settings->value("HostExplorer/"+this->uri+"/lastAccess").toDateTime();
     }
 }
 
@@ -297,9 +296,8 @@ void HostSelectionTable::reloadRows(const std::vector<NodeInfo> &nodeInfos)
         _uriToInfo[info.uri] = info;
 
         //gather information
-        auto ldt = Poco::LocalDateTime(Poco::DateTime(info.lastAccess));
-        auto timeStr = Poco::DateTimeFormatter::format(ldt, "%h:%M:%S %A - %b %e %Y");
-        auto accessTimeStr = QString(info.neverAccessed()? tr("Never") : QString::fromStdString(timeStr));
+        const auto timeStr = info.lastAccess.toString("h:mm:ss AP - MMM d yyyy");
+        const auto accessTimeStr = QString(info.lastAccess.isNull()? tr("Never") : timeStr);
         QIcon statusIcon = makeIconFromTheme(
             info.isOnline?"network-transmit-receive":"network-offline");
 

--- a/HostExplorer/HostSelectionTable.hpp
+++ b/HostExplorer/HostSelectionTable.hpp
@@ -1,11 +1,11 @@
-// Copyright (c) 2013-2014 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
 #include <Pothos/Config.hpp>
 #include <QTableWidget>
 #include <QFutureWatcher>
-#include <Poco/Timestamp.h>
+#include <QDateTime>
 #include <QString>
 #include <vector>
 #include <map>
@@ -19,20 +19,14 @@ class QTimer;
 struct NodeInfo
 {
     NodeInfo(void):
-        isOnline(false),
-        lastAccess(Poco::Timestamp::fromEpochTime(0))
+        isOnline(false)
     {}
     QString uri;
     bool isOnline;
-    Poco::Timestamp lastAccess;
+    QDateTime lastAccess;
     QString nodeName;
 
     void update(void);
-
-    bool neverAccessed(void) const
-    {
-        return this->lastAccess == Poco::Timestamp::fromEpochTime(0);
-    }
 };
 
 //! widget to selection and edit available hosts

--- a/HostExplorer/PluginModuleTree.cpp
+++ b/HostExplorer/PluginModuleTree.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "HostExplorer/PluginModuleTree.hpp"
@@ -41,7 +41,8 @@ static PluginModuleTree::ModMapType getRegistryDump(const std::string &uriStr)
     }
     catch (const Pothos::Exception &ex)
     {
-        poco_error_f2(Poco::Logger::get("PothosGui.PluginModuleTree"), "Failed to dump registry %s - %s", uriStr, ex.displayText());
+        static auto &logger = Poco::Logger::get("PothosGui.PluginModuleTree");
+        logger.error("Failed to dump registry %s - %s", uriStr, ex.displayText());
     }
     return modMap;
 }

--- a/HostExplorer/PluginRegistryTree.cpp
+++ b/HostExplorer/PluginRegistryTree.cpp
@@ -58,7 +58,8 @@ static Pothos::PluginRegistryInfoDump getRegistryDump(const std::string &uriStr)
     }
     catch (const Pothos::Exception &ex)
     {
-        poco_error_f2(Poco::Logger::get("PothosGui.PluginRegistryTree"), "Failed to dump registry %s - %s", uriStr, ex.displayText());
+        static auto &logger = Poco::Logger::get("PothosGui.PluginRegistryTree");
+        logger.error("Failed to dump registry %s - %s", uriStr, ex.displayText());
     }
     return Pothos::PluginRegistryInfoDump();
 }

--- a/HostExplorer/SystemInfoTree.cpp
+++ b/HostExplorer/SystemInfoTree.cpp
@@ -16,6 +16,7 @@
  **********************************************************************/
 static InfoResult getInfo(const std::string &uriStr)
 {
+    static auto &logger = Poco::Logger::get("PothosGui.SystemInfoTree");
     InfoResult info;
     POTHOS_EXCEPTION_TRY
     {
@@ -26,12 +27,14 @@ static InfoResult getInfo(const std::string &uriStr)
         const QByteArray devInfoBytes(deviceInfo.data(), deviceInfo.size());
         QJsonParseError errorParser;
         const auto jsonDoc = QJsonDocument::fromJson(devInfoBytes, &errorParser);
-        if (jsonDoc.isNull()) throw Poco::Exception(errorParser.errorString().toStdString());
-        info.deviceInfo = jsonDoc.array();
+        if (jsonDoc.isNull())
+        {
+            logger.error("Failed to parse device info %s - %s", uriStr, errorParser.errorString().toStdString());
+        }
+        else info.deviceInfo = jsonDoc.array();
     }
     POTHOS_EXCEPTION_CATCH(const Pothos::Exception &ex)
     {
-        static auto &logger = Poco::Logger::get("PothosGui.SystemInfoTree");
         logger.error("Failed to query system info %s - %s", uriStr, ex.displayText());
     }
     return info;

--- a/HostExplorer/SystemInfoTree.cpp
+++ b/HostExplorer/SystemInfoTree.cpp
@@ -1,17 +1,15 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "HostExplorer/SystemInfoTree.hpp"
 #include <Pothos/Remote.hpp>
 #include <Pothos/Proxy.hpp>
 #include <Pothos/System.hpp>
+#include <QJsonDocument>
 #include <QFuture>
 #include <QFutureWatcher>
 #include <QtConcurrent/QtConcurrent>
 #include <Poco/Logger.h>
-#include <Poco/JSON/Parser.h>
-#include <Poco/JSON/Object.h>
-#include <Poco/JSON/Array.h>
 
 /***********************************************************************
  * information aquisition
@@ -25,8 +23,11 @@ static InfoResult getInfo(const std::string &uriStr)
         info.hostInfo = env->findProxy("Pothos/System/HostInfo").call<Pothos::System::HostInfo>("get");
         info.numaInfo = env->findProxy("Pothos/System/NumaInfo").call<std::vector<Pothos::System::NumaInfo>>("get");
         auto deviceInfo = env->findProxy("Pothos/Util/DeviceInfoUtils").call<std::string>("dumpJson");
-        const auto result = Poco::JSON::Parser().parse(deviceInfo);
-        info.deviceInfo = result.extract<Poco::JSON::Array::Ptr>();
+        const QByteArray devInfoBytes(deviceInfo.data(), deviceInfo.size());
+        QJsonParseError errorParser;
+        const auto jsonDoc = QJsonDocument::fromJson(devInfoBytes, &errorParser);
+        if (jsonDoc.isNull()) throw Poco::Exception(errorParser.errorString().toStdString());
+        info.deviceInfo = jsonDoc.array();
     }
     POTHOS_EXCEPTION_CATCH(const Pothos::Exception &ex)
     {
@@ -72,12 +73,12 @@ void SystemInfoTree::handleWatcherDone(void)
         columns.push_back(tr("Host Info"));
         auto rootItem = new QTreeWidgetItem(this, columns);
         rootItem->setExpanded(true);
-        makeEntry(rootItem, "OS Name", hostInfo.osName);
-        makeEntry(rootItem, "OS Version", hostInfo.osVersion);
-        makeEntry(rootItem, "OS Architecture", hostInfo.osArchitecture);
-        makeEntry(rootItem, "Node Name", hostInfo.nodeName);
-        makeEntry(rootItem, "Node ID", hostInfo.nodeId);
-        makeEntry(rootItem, "Processors", std::to_string(hostInfo.processorCount), "CPUs");
+        makeEntry(rootItem, "OS Name", QString::fromStdString(hostInfo.osName));
+        makeEntry(rootItem, "OS Version", QString::fromStdString(hostInfo.osVersion));
+        makeEntry(rootItem, "OS Architecture", QString::fromStdString(hostInfo.osArchitecture));
+        makeEntry(rootItem, "Node Name", QString::fromStdString(hostInfo.nodeName));
+        makeEntry(rootItem, "Node ID", QString::fromStdString(hostInfo.nodeId));
+        makeEntry(rootItem, "Processors", QString::number(hostInfo.processorCount), "CPUs");
     }
 
     for (const auto &numaInfo : info.numaInfo)
@@ -86,13 +87,13 @@ void SystemInfoTree::handleWatcherDone(void)
         columns.push_back(tr("NUMA Node %1 Info").arg(numaInfo.nodeNumber));
         auto rootItem = new QTreeWidgetItem(this, columns);
         rootItem->setExpanded(numaInfo.nodeNumber == 0);
-        if (numaInfo.totalMemory != 0) makeEntry(rootItem, "Total Memory", std::to_string(numaInfo.totalMemory/1024/1024), "MB");
-        if (numaInfo.freeMemory != 0) makeEntry(rootItem, "Free Memory", std::to_string(numaInfo.freeMemory/1024/1024), "MB");
-        std::string cpuStr;
+        if (numaInfo.totalMemory != 0) makeEntry(rootItem, "Total Memory", QString::number(numaInfo.totalMemory/1024/1024), "MB");
+        if (numaInfo.freeMemory != 0) makeEntry(rootItem, "Free Memory", QString::number(numaInfo.freeMemory/1024/1024), "MB");
+        QString cpuStr;
         for (auto i : numaInfo.cpus)
         {
-            if (not cpuStr.empty()) cpuStr += ", ";
-            cpuStr += std::to_string(i);
+            if (not cpuStr.isEmpty()) cpuStr += ", ";
+            cpuStr += QString::number(i);
         }
         makeEntry(rootItem, "CPUs", cpuStr);
     }
@@ -100,9 +101,9 @@ void SystemInfoTree::handleWatcherDone(void)
     //adjust value column before arbitrary values from device info
     this->resizeColumnToContents(1);
 
-    if (info.deviceInfo) for (size_t i = 0; i < info.deviceInfo->size(); i++)
+    for (const auto &infoVal : info.deviceInfo)
     {
-        this->loadJsonObject(this, "", info.deviceInfo->getObject(i), true/*expand*/);
+        this->loadJsonObject(this, "", infoVal.toObject(), true/*expand*/);
     }
 
     //adjust names and units columns after all information is loaded

--- a/HostExplorer/SystemInfoTree.cpp
+++ b/HostExplorer/SystemInfoTree.cpp
@@ -31,7 +31,8 @@ static InfoResult getInfo(const std::string &uriStr)
     }
     POTHOS_EXCEPTION_CATCH(const Pothos::Exception &ex)
     {
-        poco_error_f2(Poco::Logger::get("PothosGui.SystemInfoTree"), "Failed to query system info %s - %s", uriStr, ex.displayText());
+        static auto &logger = Poco::Logger::get("PothosGui.SystemInfoTree");
+        logger.error("Failed to query system info %s - %s", uriStr, ex.displayText());
     }
     return info;
 }

--- a/HostExplorer/SystemInfoTree.hpp
+++ b/HostExplorer/SystemInfoTree.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -7,8 +7,8 @@
 #include <QFutureWatcher>
 #include <QTreeWidgetItem>
 #include <QStringList>
-#include <Poco/JSON/Object.h>
-#include <Poco/JSON/Array.h>
+#include <QJsonObject>
+#include <QJsonArray>
 #include <Pothos/System.hpp>
 #include <string>
 
@@ -16,7 +16,7 @@ struct InfoResult
 {
     Pothos::System::HostInfo hostInfo;
     std::vector<Pothos::System::NumaInfo> numaInfo;
-    Poco::JSON::Array::Ptr deviceInfo;
+    QJsonArray deviceInfo;
 };
 
 //! tree widget display for a host's system info
@@ -40,54 +40,53 @@ private slots:
 private:
 
     template <typename Parent>
-    static QTreeWidgetItem *makeEntry(Parent *root, const std::string &name, const std::string &value, const char *unit = "")
+    static QTreeWidgetItem *makeEntry(Parent *root, const QString &name, const QString &value, const char *unit = "")
     {
         QStringList columns;
-        columns.push_back(QString::fromStdString(name));
-        columns.push_back(QString::fromStdString(value));
+        columns.push_back(name);
+        columns.push_back(value);
         columns.push_back(unit);
         return new QTreeWidgetItem(root, columns);
     }
 
     template <typename Parent>
-    void loadJsonObject(Parent *root, const std::string &rootName, const Poco::JSON::Object::Ptr &obj, const bool expand = false)
+    void loadJsonObject(Parent *root, const QString &rootName, const QJsonObject &obj, const bool expand = false)
     {
-        std::vector<std::string> names; obj->getNames(names);
-        for (const auto &name : names)
+        for (const auto &name : obj.keys())
         {
-            std::string newName = name;
-            if (not rootName.empty()) newName = rootName + " " + name;
-            loadJsonVar(root, newName, obj->get(name), expand);
+            QString newName = name;
+            if (not rootName.isEmpty()) newName = rootName + " " + name;
+            loadJsonVar(root, newName, obj[name], expand);
         }
     }
 
     template <typename Parent>
-    void loadJsonArray(Parent *root, const std::string &rootName, const Poco::JSON::Array::Ptr &arr, const bool expand = false)
+    void loadJsonArray(Parent *root, const QString &rootName, const QJsonArray &arr, const bool expand = false)
     {
-        for (size_t i = 0; i < arr->size(); i++)
+        for (int i = 0; i < arr.size(); i++)
         {
-            loadJsonVar(root, rootName + " " + std::to_string(i), arr->get(i), expand and (i == 0));
+            loadJsonVar(root, rootName + " " + QString::number(i), arr.at(i), expand and (i == 0));
         }
     }
 
     template <typename Parent>
-    void loadJsonVar(Parent *root, const std::string &rootName, const Poco::Dynamic::Var &var, const bool expand = false)
+    void loadJsonVar(Parent *root, const QString &rootName, const QJsonValue &var, const bool expand = false)
     {
-        if (var.type() == typeid(Poco::JSON::Array::Ptr))
+        if (var.isArray())
         {
-            this->loadJsonArray(root, rootName, var.extract<Poco::JSON::Array::Ptr>(), expand);
+            this->loadJsonArray(root, rootName, var.toArray(), expand);
         }
-        else if (var.type() == typeid(Poco::JSON::Object::Ptr))
+        else if (var.isObject())
         {
             QStringList columns;
-            columns.push_back(QString::fromStdString(rootName));
+            columns.push_back(rootName);
             auto rootItem = new QTreeWidgetItem(root, columns);
             rootItem->setExpanded(expand);
-            this->loadJsonObject(rootItem, "", var.extract<Poco::JSON::Object::Ptr>());
+            this->loadJsonObject(rootItem, "", var.toObject());
         }
         else
         {
-            auto entry = makeEntry(root, rootName, var.convert<std::string>());
+            auto entry = makeEntry(root, rootName, var.toString());
             entry->setExpanded(expand);
         }
     }

--- a/MainWindow/MainSettings.cpp
+++ b/MainWindow/MainSettings.cpp
@@ -1,9 +1,9 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "MainWindow/MainSettings.hpp"
 #include <Pothos/System.hpp>
-#include <Poco/Path.h>
+#include <QDir>
 
 static MainSettings *globalMainSettings = nullptr;
 
@@ -14,9 +14,9 @@ MainSettings *MainSettings::global(void)
 
 static QString getSettingsPath(void)
 {
-    Poco::Path path(Pothos::System::getUserConfigPath());
-    path.append("PothosGui.conf");
-    return QString::fromStdString(path.toString());
+    const auto confPath = Pothos::System::getUserConfigPath();
+    const QDir confDir(QString::fromStdString(confPath));
+    return confDir.absoluteFilePath("PothosGui.conf");
 }
 
 MainSettings::MainSettings(QObject *parent):

--- a/MainWindow/MainWindow.cpp
+++ b/MainWindow/MainWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "MainWindow/MainWindow.hpp"
@@ -66,7 +66,7 @@ MainWindow::MainWindow(QWidget *parent):
     _splash->postMessage(tr("Creating message window..."));
     auto messageWindowDock = new MessageWindowDock(this);
     this->addDockWidget(Qt::BottomDockWidgetArea, messageWindowDock);
-    poco_information_f1(_logger, "Welcome to Pothos v%s", Pothos::System::getLibVersion());
+    _logger.information("Welcome to Pothos v%s", Pothos::System::getLibVersion());
 
     //create graph actions dock
     _splash->postMessage(tr("Creating actions dock..."));
@@ -137,7 +137,7 @@ MainWindow::MainWindow(QWidget *parent):
 
 MainWindow::~MainWindow(void)
 {
-    poco_information(_logger, "Save application state");
+    _logger.information("Save application state");
     this->handleFullScreenViewAction(false); //undo if set -- so we dont save full mode below
     _settings->setValue("MainWindow/geometry", this->saveGeometry());
     _settings->setValue("MainWindow/state", this->saveState());
@@ -152,12 +152,12 @@ MainWindow::~MainWindow(void)
 
     //cleanup widgets which may use plugins or the server
     //this includes active graph blocks and eval engines
-    poco_information(_logger, "Shutdown graph editor");
+    _logger.information("Shutdown graph editor");
     delete _editorTabs;
 
     //unload the plugins
     //increase the log level to avoid deinit verbose
-    poco_information(_logger, "Unload Pothos plugins");
+    _logger.information("Unload Pothos plugins");
     Poco::Logger::get("").setLevel(Poco::Message::PRIO_INFORMATION);
     Pothos::deinit();
 
@@ -169,7 +169,7 @@ void MainWindow::handleInitDone(void)
 {
     _splash->postMessage(tr("Completing initialization..."));
     _splash->finish(this);
-    poco_information(_logger, "Initialization complete");
+    _logger.information("Initialization complete");
 }
 
 void MainWindow::handleNewTitleSubtext(const QString &s)
@@ -256,7 +256,7 @@ void MainWindow::handleReloadPlugins(void)
         if (editor != nullptr) editor->restartEvaluation();
     }
 
-    poco_information(Poco::Logger::get("PothosGui.MainWindow"), "Reload plugins complete");
+    _logger.information("Reload plugins complete");
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)

--- a/MessageWindow/LoggerChannel.cpp
+++ b/MessageWindow/LoggerChannel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "MessageWindow/LoggerChannel.hpp"
@@ -14,7 +14,7 @@ LoggerChannel::LoggerChannel(QObject *parent):
 {
     _logger.setLevel(Poco::Message::PRIO_TRACE); //lowest level -> shows everything
     if (_splitter) _splitter->addChannel(this);
-    else poco_error(Poco::Logger::get("PothosGui.LoggerChannel"), "expected SplitterChannel");
+    else Poco::Logger::get("PothosGui.LoggerChannel").error("expected SplitterChannel");
 }
 
 LoggerChannel::~LoggerChannel(void)

--- a/PothosGui.cpp
+++ b/PothosGui.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 Josh Blum
+// Copyright (c) 2013-2017 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "MainWindow/MainWindow.hpp"
@@ -12,6 +12,20 @@
 #include <QDir>
 #include <stdexcept>
 #include <cstdlib> //EXIT_FAILURE
+
+static void myQLogHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+    Poco::Message::Priority prio(Poco::Message::PRIO_INFORMATION);
+    switch (type) {
+    case QtDebugMsg: prio = Poco::Message::PRIO_DEBUG; break;
+    case QtInfoMsg: prio = Poco::Message::PRIO_INFORMATION; break;
+    case QtWarningMsg: prio = Poco::Message::PRIO_WARNING; break;
+    case QtCriticalMsg: prio = Poco::Message::PRIO_CRITICAL; break;
+    case QtFatalMsg: prio = Poco::Message::PRIO_FATAL; break;
+    }
+    const Poco::Message message(context.category, msg.toStdString(), prio, context.file, context.line);
+    Poco::Logger::get(context.category).log(message);
+}
 
 struct MyScopedSyslogListener
 {
@@ -29,6 +43,7 @@ struct MyScopedSyslogListener
 
 int main(int argc, char **argv)
 {
+    qInstallMessageHandler(myQLogHandler);
     MyScopedSyslogListener syslogListener;
 
     //did the user specified files on the command line?

--- a/PropertiesPanel/BlockPropertiesPanel.cpp
+++ b/PropertiesPanel/BlockPropertiesPanel.cpp
@@ -228,8 +228,8 @@ BlockPropertiesPanel::BlockPropertiesPanel(GraphBlock *block, QWidget *parent):
 
     connect(_block, SIGNAL(destroyed(QObject*)), this, SLOT(handleBlockDestroyed(QObject*)));
     connect(_block, SIGNAL(evalDoneEvent(void)), this, SLOT(handleBlockEvalDone(void)));
-    connect(_block, SIGNAL(paramDescChanged(const QString &, const Poco::JSON::Object::Ptr &)),
-            this, SLOT(handleParamDescChanged(const QString &, const Poco::JSON::Object::Ptr &)));
+    connect(_block, SIGNAL(paramDescChanged(const QString &, const QJsonObject &)),
+            this, SLOT(handleParamDescChanged(const QString &, const QJsonObject &)));
     this->updateAllForms();
     _ignoreChanges = false;
 }

--- a/PropertiesPanel/BlockPropertiesPanel.hpp
+++ b/PropertiesPanel/BlockPropertiesPanel.hpp
@@ -5,9 +5,9 @@
 #include <Pothos/Config.hpp>
 #include <QWidget>
 #include <QString>
+#include <QJsonObject>
 #include "GraphEditor/GraphState.hpp"
 #include "GraphObjects/GraphBlock.hpp"
-#include <Poco/JSON/Object.h>
 #include <map>
 
 class GraphBlock;
@@ -41,7 +41,7 @@ private slots:
 
     void handleBlockEvalDone(void);
 
-    void handleParamDescChanged(const QString &, const Poco::JSON::Object::Ptr &);
+    void handleParamDescChanged(const QString &, const QJsonObject &);
 
     void handleDocTabChanged(int);
 
@@ -77,8 +77,8 @@ private:
     QLabel *_jsonBlockDesc;
     QLabel *_evalTypesDesc;
     QFormLayout *_formLayout;
-    std::map<std::string, QFormLayout *> _paramLayouts;
+    std::map<QString, QFormLayout *> _paramLayouts;
     QTabWidget *_propertiesTabs;
-    std::map<QWidget *, std::string> _tabWidgetToTabName;
+    std::map<QWidget *, QString> _tabWidgetToTabName;
     QPointer<GraphBlock> _block;
 };

--- a/PropertiesPanel/GraphPropertiesPanel.cpp
+++ b/PropertiesPanel/GraphPropertiesPanel.cpp
@@ -261,7 +261,7 @@ void GraphPropertiesPanel::updateAllVariableForms(void)
             auto obj = evalEnv.eval(name.toStdString());
             const auto typeStr = obj.getTypeString();
             const auto toString = obj.toString();
-            editWidget->setTypeStr(typeStr);
+            editWidget->setTypeStr(QString::fromStdString(typeStr));
             editWidget->setErrorMsg(""); //clear errors
             editWidget->setToolTip(QString::fromStdString(toString));
         }
@@ -283,8 +283,7 @@ void GraphPropertiesPanel::createVariableEditWidget(const QString &name)
     editLayout->setContentsMargins(QMargins());
 
     //create edit widget
-    const Poco::JSON::Object::Ptr paramDesc(new Poco::JSON::Object());
-    auto editWidget = new PropertyEditWidget(_graphEditor->getGlobalExpression(name), paramDesc, "", this);
+    auto editWidget = new PropertyEditWidget(_graphEditor->getGlobalExpression(name), QJsonObject(), "", this);
     connect(editWidget, SIGNAL(widgetChanged(void)), this, SLOT(updateAllVariableForms(void)));
     //connect(editWidget, SIGNAL(entryChanged(void)), this, SLOT(updateAllVariableForms(void)));
     connect(editWidget, SIGNAL(commitRequested(void)), this, SLOT(handleCommit(void)));

--- a/PropertiesPanel/PropertyEditWidget.cpp
+++ b/PropertiesPanel/PropertyEditWidget.cpp
@@ -20,7 +20,7 @@
  */
 static const long UPDATE_TIMER_MS = 500;
 
-PropertyEditWidget::PropertyEditWidget(const QString &initialValue, const Poco::JSON::Object::Ptr &paramDesc, const QString &editMode, QWidget *parent):
+PropertyEditWidget::PropertyEditWidget(const QString &initialValue, const QJsonObject &paramDesc, const QString &editMode, QWidget *parent):
     _initialValue(initialValue),
     _editWidget(nullptr),
     _errorLabel(new QLabel(this)),
@@ -63,7 +63,7 @@ PropertyEditWidget::~PropertyEditWidget(void)
     delete _formLabel;
 }
 
-void PropertyEditWidget::reloadParamDesc(const Poco::JSON::Object::Ptr &paramDesc)
+void PropertyEditWidget::reloadParamDesc(const QJsonObject &paramDesc)
 {
     _lastParamDesc = paramDesc;
 
@@ -75,15 +75,15 @@ void PropertyEditWidget::reloadParamDesc(const Poco::JSON::Object::Ptr &paramDes
     delete _editWidget;
 
     //extract widget type
-    auto widgetType = paramDesc->optValue<std::string>("widgetType", "LineEdit");
-    if (paramDesc->isArray("options")) widgetType = "ComboBox";
-    if (widgetType.empty()) widgetType = "LineEdit";
-    _unitsStr = QString::fromStdString(paramDesc->optValue<std::string>("units", ""));
+    auto widgetType = paramDesc["widgetType"].toString("LineEdit");
+    if (paramDesc.contains("options")) widgetType = "ComboBox";
+    if (widgetType.isEmpty()) widgetType = "LineEdit";
+    _unitsStr = paramDesc["units"].toString();
 
     //check if the widget type exists in the plugin tree
-    if (not Pothos::PluginRegistry::exists(Pothos::PluginPath("/gui/EntryWidgets").join(widgetType)))
+    if (not Pothos::PluginRegistry::exists(Pothos::PluginPath("/gui/EntryWidgets").join(widgetType.toStdString())))
     {
-        poco_error_f1(Poco::Logger::get("PothosGui.BlockPropertiesPanel"), "widget type %s does not exist", widgetType);
+        Poco::Logger::get("PothosGui.BlockPropertiesPanel").error("widget type %s does not exist", widgetType.toStdString());
         widgetType = "LineEdit";
     }
 
@@ -92,7 +92,7 @@ void PropertyEditWidget::reloadParamDesc(const Poco::JSON::Object::Ptr &paramDes
     if (_editMode == "raw") widgetType = "LineEdit";
 
     //lookup the plugin to get the entry widget factory
-    const auto plugin = Pothos::PluginRegistry::get(Pothos::PluginPath("/gui/EntryWidgets").join(widgetType));
+    const auto plugin = Pothos::PluginRegistry::get(Pothos::PluginPath("/gui/EntryWidgets").join(widgetType.toStdString()));
     const auto &factory = plugin.getObject().extract<Pothos::Callable>();
     _editWidget = factory.call<QWidget *>(paramDesc, static_cast<QWidget *>(_editParent));
     _editWidget->setLocale(QLocale::C);
@@ -134,7 +134,7 @@ void PropertyEditWidget::setValue(const QString &value)
     QMetaObject::invokeMethod(_editWidget, "setValue", Qt::DirectConnection, Q_ARG(QString, value));
 }
 
-void PropertyEditWidget::setTypeStr(const std::string &typeStr)
+void PropertyEditWidget::setTypeStr(const QString &typeStr)
 {
     this->setBackgroundColor(typeStrToColor(typeStr));
 }

--- a/PropertiesPanel/PropertyEditWidget.cpp
+++ b/PropertiesPanel/PropertyEditWidget.cpp
@@ -83,7 +83,8 @@ void PropertyEditWidget::reloadParamDesc(const QJsonObject &paramDesc)
     //check if the widget type exists in the plugin tree
     if (not Pothos::PluginRegistry::exists(Pothos::PluginPath("/gui/EntryWidgets").join(widgetType.toStdString())))
     {
-        Poco::Logger::get("PothosGui.BlockPropertiesPanel").error("widget type %s does not exist", widgetType.toStdString());
+        static auto &logger = Poco::Logger::get("PothosGui.BlockPropertiesPanel");
+        logger.error("widget type %s does not exist", widgetType.toStdString());
         widgetType = "LineEdit";
     }
 

--- a/PropertiesPanel/PropertyEditWidget.hpp
+++ b/PropertiesPanel/PropertyEditWidget.hpp
@@ -6,7 +6,7 @@
 #include <QWidget>
 #include <QString>
 #include <QPointer>
-#include <Poco/JSON/Object.h>
+#include <QJsonObject>
 #include <string>
 
 class QLabel;
@@ -29,12 +29,12 @@ public:
      * Make a new edit widget from a JSON description.
      * The initial value allows the widget to determine if a change occurred.
      */
-    PropertyEditWidget(const QString &initialValue, const Poco::JSON::Object::Ptr &paramDesc, const QString &editMode, QWidget *parent);
+    PropertyEditWidget(const QString &initialValue, const QJsonObject &paramDesc, const QString &editMode, QWidget *parent);
 
     ~PropertyEditWidget(void);
 
     //! Reload internal edit widget from a param desc change
-    void reloadParamDesc(const Poco::JSON::Object::Ptr &paramDesc);
+    void reloadParamDesc(const QJsonObject &paramDesc);
 
     //! Get the initial value of the edit widget
     const QString &initialValue(void) const;
@@ -49,7 +49,7 @@ public:
     void setValue(const QString &value);
 
     //! Set the type string from an evaluation
-    void setTypeStr(const std::string &typeStr);
+    void setTypeStr(const QString &typeStr);
 
     //! Set the error message from an evaluation
     void setErrorMsg(const QString &errorMsg);
@@ -110,5 +110,5 @@ private:
     QColor _bgColor;
     QString _initialEditMode;
     QString _editMode;
-    Poco::JSON::Object::Ptr _lastParamDesc;
+    QJsonObject _lastParamDesc;
 };


### PR DESCRIPTION
Switch to Qt classes in many places (except logging). This simplified a lot of the string conversion within the codebase (std::string to/from QString). The Qt JSON API is also very clean. This requires some matching changes to the core library for remote block handling which reduces the amount of JSON objects passing around to the block eval class.

* pothos plotters also updated for EditWidget factory changes
* requires pothos 0.5 (master branch)
* resolves https://github.com/pothosware/pothos-gui/issues/136