### PR TITLE
Fix rendering of blocks with dynamic and possibly zero input/output ports

### DIFF
--- a/EvalEngine/BlockEval.cpp
+++ b/EvalEngine/BlockEval.cpp
@@ -73,9 +73,12 @@ bool BlockEval::isReady(void) const
 bool BlockEval::portExists(const QString &name, const bool isInput) const
 {
     const auto portDesc = isInput?_lastBlockStatus.inPortDesc:_lastBlockStatus.outPortDesc;
-    for (const auto &val : portDesc)
+    if (portDesc.isSpecified())
     {
-        if (val.toObject()["name"].toString() == name) return true;
+        for (const auto &val : portDesc.value())
+        {
+            if (val.toObject()["name"].toString() == name) return true;
+        }
     }
     return false;
 }
@@ -348,8 +351,14 @@ void BlockEval::postStatusToBlock(const BlockStatus &status)
     {
         block->addBlockErrorMsg(errMsg);
     }
-    block->setInputPortDesc(status.inPortDesc);
-    block->setOutputPortDesc(status.outPortDesc);
+    if (status.inPortDesc.isSpecified())
+    {
+        block->setInputPortDesc(status.inPortDesc.value());
+    }
+    if (status.outPortDesc.isSpecified())
+    {
+        block->setOutputPortDesc(status.outPortDesc.value());
+    }
     block->setGraphWidget(status.widget);
     block->setOverlayDesc(status.overlayDesc);
 

--- a/EvalEngine/BlockEval.cpp
+++ b/EvalEngine/BlockEval.cpp
@@ -348,14 +348,8 @@ void BlockEval::postStatusToBlock(const BlockStatus &status)
     {
         block->addBlockErrorMsg(errMsg);
     }
-    if (not status.inPortDesc.isEmpty())
-    {
-        block->setInputPortDesc(status.inPortDesc);
-    }
-    if (not status.outPortDesc.isEmpty())
-    {
-        block->setOutputPortDesc(status.outPortDesc);
-    }
+    block->setInputPortDesc(status.inPortDesc);
+    block->setOutputPortDesc(status.outPortDesc);
     block->setGraphWidget(status.widget);
     block->setOverlayDesc(status.overlayDesc);
 

--- a/EvalEngine/BlockEval.hpp
+++ b/EvalEngine/BlockEval.hpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <chrono>
 #include <Poco/Logger.h>
+#include <Poco/Optional.h>
 
 class EnvironmentEval;
 class ThreadPoolEval;
@@ -51,8 +52,8 @@ struct BlockStatus
     std::map<QString, QString> propertyTypeInfos;
     std::map<QString, QString> propertyErrorMsgs;
     QStringList blockErrorMsgs;
-    QJsonArray inPortDesc;
-    QJsonArray outPortDesc;
+    Poco::Optional<QJsonArray> inPortDesc;
+    Poco::Optional<QJsonArray> outPortDesc;
     QJsonObject overlayDesc;
     QByteArray overlayDescStr;
     std::chrono::high_resolution_clock::time_point overlayExpired;


### PR DESCRIPTION
Commit [8149f9f](https://github.com/pothosware/pothos-gui/commit/8149f9f4a4d6bc22a5fa89e802b7fcafd14b5f1f) breaks rendering of ports which can have dynamic and possibly zero input/output ports. Specifically, when a block with a non-zero number of ports is re-constructed to have zero ports, the old ports remain displayed in the graph editor. This occurs because empty port description arrays are not being forwarded to the GraphBlock object.

It seems to me that reverting this chunk of the commit should be safe, since the port descriptions are cached in `_lastBlockStatus` and are only altered when the block is (re-)evaluated.