### PR TITLE
Suggested layout improvement of DTypeChooser control when dim SpinBox is visible.

### DIFF
--- a/EditWidgets/DTypeChooser.cpp
+++ b/EditWidgets/DTypeChooser.cpp
@@ -26,16 +26,14 @@ public:
         auto layout = new QHBoxLayout(this);
         layout->setContentsMargins(QMargins());
 
-        layout->addWidget(_comboBox);
+        layout->addWidget(_comboBox, 1);
         connect(_comboBox, SIGNAL(currentIndexChanged(const QString &)), this, SLOT(handleWidgetChanged(const QString &)));
         connect(_comboBox, SIGNAL(editTextChanged(const QString &)), this, SLOT(handleEntryChanged(const QString &)));
 
         if (editDimension)
         {
             _spinBox = new QSpinBox(this);
-            layout->addWidget(_spinBox);
-            _spinBox->setMaximumSize(50, _spinBox->height());
-            _spinBox->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+            layout->addWidget(_spinBox, 0);
             _spinBox->setPrefix("x");
             _spinBox->setMinimum(1);
             _spinBox->setMaximum(std::numeric_limits<int>::max());


### PR DESCRIPTION
The edit box part of the QSpinBox was not visible at all and part of the first arrow was missing.
I have only test this fix under Qt 5.7.1 under Linux and works fine, not sure about other system.