### PR TITLE
Signal slots style

### DIFF
--- a/AffinitySupport/AffinityZoneEditor.cpp
+++ b/AffinitySupport/AffinityZoneEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "MainWindow/FormLayout.hpp"
@@ -72,7 +72,7 @@ AffinityZoneEditor::AffinityZoneEditor(const QString &zoneName, QWidget *parent,
         formLayout->addRow(tr("Host URI"), _hostsBox);
         _hostsBox->setEditable(true);
         _hostsBox->setToolTip(tr("Select the URI for a local or remote host"));
-        connect(_hostsBox, SIGNAL(activated(int)), this, SLOT(handleUriChanged(int)));
+        connect(_hostsBox, QOverload<int>::of(&QComboBox::activated), this, &AffinityZoneEditor::handleUriChanged);
         connect(_hostExplorerDock, &HostExplorerDock::hostUriListChanged, this, &AffinityZoneEditor::handleHostListChanged);
         this->handleHostListChanged();
     }
@@ -115,7 +115,7 @@ AffinityZoneEditor::AffinityZoneEditor(const QString &zoneName, QWidget *parent,
         _yieldModeBox->addItem(tr("Hybrid"), "HYBRID");
         _yieldModeBox->addItem(tr("Spin"), "SPIN");
         _yieldModeBox->setToolTip(tr("Yield mode specifies the internal threading mechanisms"));
-        connect(_yieldModeBox, SIGNAL(activated(int)), this, SLOT(handleComboChanged(int)));
+        connect(_yieldModeBox, QOverload<int>::of(&QComboBox::activated), this, &AffinityZoneEditor::handleComboChanged);
     }
 }
 

--- a/AffinitySupport/AffinityZonesDock.hpp
+++ b/AffinitySupport/AffinityZonesDock.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -13,7 +13,6 @@ class QComboBox;
 class QLineEdit;
 class QPushButton;
 class QTabWidget;
-class QSignalMapper;
 class AffinityZoneEditor;
 class HostExplorerDock;
 
@@ -54,10 +53,6 @@ signals:
 private slots:
     void handleCreateZone(void);
     void handleTabCloseRequested(int);
-    void handleZoneEditorChanged(void)
-    {
-        this->saveAffinityZoneEditorsState();
-    }
     void handleTabSelectionChanged(int);
     void updateTabColors(void);
 
@@ -73,7 +68,6 @@ private:
     void handleErrorMessage(const QString &errMsg);
 
     HostExplorerDock *_hostExplorerDock;
-    QSignalMapper *_mapper;
     QLineEdit *_zoneEntry;
     QPushButton *_createButton;
     QTabWidget *_editorsTabs;

--- a/AffinitySupport/AffinityZonesMenu.cpp
+++ b/AffinitySupport/AffinityZonesMenu.cpp
@@ -1,16 +1,13 @@
-// Copyright (c) 2014-2014 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "AffinitySupport/AffinityZonesMenu.hpp"
 #include "AffinitySupport/AffinityZonesDock.hpp"
-#include <QSignalMapper>
 
 AffinityZonesMenu::AffinityZonesMenu(AffinityZonesDock *dock, QWidget *parent):
     QMenu(tr("Graph blocks affinity..."), parent),
-    _clickMapper(new QSignalMapper(this)),
     _dock(dock)
 {
-    connect(_clickMapper, SIGNAL(mapped(const QString &)), this, SLOT(handleMapperClicked(const QString &)));
     connect(_dock, &AffinityZonesDock::zonesChanged, this, &AffinityZonesMenu::handleZonesChanged);
     this->handleZonesChanged(); //init
 }
@@ -21,23 +18,15 @@ void AffinityZonesMenu::handleZonesChanged(void)
 
     //clear affinity setting
     auto clearAction = this->addAction(tr("Clear affinity"));
-    connect(clearAction, SIGNAL(triggered(void)), _clickMapper, SLOT(map(void)));
-    _clickMapper->setMapping(clearAction, "");
+    connect(clearAction, &QAction::triggered, [=](int){emit this->zoneClicked("");});
 
     //gui affinity setting
     auto guiAction = this->addAction(tr("GUI affinity"));
-    connect(guiAction, SIGNAL(triggered(void)), _clickMapper, SLOT(map(void)));
-    _clickMapper->setMapping(guiAction, "gui");
+    connect(guiAction, &QAction::triggered, [=](int){emit this->zoneClicked("gui");});
 
     if (_dock) for (const auto &name : _dock->zones())
     {
         auto action = this->addAction(tr("Apply %1").arg(name));
-        connect(action, SIGNAL(triggered(void)), _clickMapper, SLOT(map(void)));
-        _clickMapper->setMapping(action, name);
+        connect(action, &QAction::triggered, [=](int){emit this->zoneClicked(name);});
     }
-}
-
-void AffinityZonesMenu::handleMapperClicked(const QString &name)
-{
-    emit this->zoneClicked(name);
 }

--- a/AffinitySupport/AffinityZonesMenu.hpp
+++ b/AffinitySupport/AffinityZonesMenu.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2014 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -7,7 +7,6 @@
 #include <QMenu>
 #include <QPointer>
 
-class QSignalMapper;
 class AffinityZonesDock;
 
 /*!
@@ -25,9 +24,7 @@ signals:
 
 private slots:
     void handleZonesChanged(void);
-    void handleMapperClicked(const QString &);
 
 private:
-    QSignalMapper *_clickMapper;
     QPointer<AffinityZonesDock> _dock;
 };

--- a/BlockTree/BlockTreeWidget.cpp
+++ b/BlockTree/BlockTreeWidget.cpp
@@ -35,7 +35,7 @@ BlockTreeWidget::BlockTreeWidget(QWidget *parent, GraphEditorTabs *editorTabs):
     _filttimer->setInterval(UPDATE_TIMER_MS);
 
     connect(this, &BlockTreeWidget::itemSelectionChanged, this, &BlockTreeWidget::handleSelectionChange);
-    connect(this, SIGNAL(itemDoubleClicked(QTreeWidgetItem *, int)), this, SLOT(handleItemDoubleClicked(QTreeWidgetItem *, int)));
+    connect(this, &BlockTreeWidget::itemDoubleClicked, this, &BlockTreeWidget::handleItemDoubleClicked);
     connect(_filttimer, &QTimer::timeout, this, &BlockTreeWidget::handleFilterTimerExpired);
 }
 

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3,6 +3,7 @@ This this the changelog file for the Pothos Flow toolkit.
 Release 0.7.1 (pending)
 ==========================
 
+- Switch signal/slots to newer Qt style
 - Support systems with dark mode themes
 - Update build to support Qt6 and newer cmake target style
 - Fixed deprecated Qt API usage

--- a/EditWidgets/CheckBox.cpp
+++ b/EditWidgets/CheckBox.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2017 Josh Blum
+// Copyright (c) 2017-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Plugin.hpp>
@@ -18,7 +18,7 @@ public:
         _onText(onText),
         _offText(offText)
     {
-        connect(this, SIGNAL(toggled(bool)), this, SLOT(handleToggled(bool)));
+        connect(this, &QCheckBox::toggled, this, &CheckBox::handleToggled);
     }
 
 public slots:

--- a/EditWidgets/ColorPicker.cpp
+++ b/EditWidgets/ColorPicker.cpp
@@ -41,7 +41,7 @@ public:
             this->insertColor(QColor(253,253,150), tr("Pastel yellow"));
         }
         else throw std::runtime_error("ColorPicker mode must be default or pastel");
-        connect(this, SIGNAL(colorChanged(const QColor &)), this, SLOT(handleColorChanged(const QColor &)));
+        connect(this, &QtColorPicker::colorChanged, this, &ColorPicker::handleColorChanged);
     }
 
 public slots:

--- a/EditWidgets/ComboBox.cpp
+++ b/EditWidgets/ComboBox.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Plugin.hpp>
@@ -19,8 +19,8 @@ public:
         QComboBox(parent),
         _nonEditCount(0)
     {
-        connect(this, SIGNAL(currentIndexChanged(int)), this, SLOT(handleWidgetChanged(int)));
-        connect(this, SIGNAL(editTextChanged(const QString &)), this, SLOT(handleEntryChanged(const QString &)));
+        connect(this, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ComboBox::handleWidgetChanged);
+        connect(this, &QComboBox::editTextChanged, this, &ComboBox::handleEntryChanged);
         this->view()->setObjectName("BlockPropertiesEditWidget"); //to pick up eval color style
     }
 
@@ -30,7 +30,7 @@ public:
         //line-edit should be non-null when enabled
         if (this->lineEdit() != nullptr)
         {
-            connect(this->lineEdit(), SIGNAL(returnPressed(void)), this, SIGNAL(commitRequested(void)));
+            connect(this->lineEdit(), &QLineEdit::returnPressed, this, &ComboBox::commitRequested);
         }
     }
 

--- a/EditWidgets/DTypeChooser.cpp
+++ b/EditWidgets/DTypeChooser.cpp
@@ -27,8 +27,8 @@ public:
         layout->setContentsMargins(QMargins());
 
         layout->addWidget(_comboBox, 1);
-        connect(_comboBox, SIGNAL(currentIndexChanged(const QString &)), this, SLOT(handleWidgetChanged(const QString &)));
-        connect(_comboBox, SIGNAL(editTextChanged(const QString &)), this, SLOT(handleEntryChanged(const QString &)));
+        connect(_comboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), [=](int){emit this->widgetChanged();});
+        connect(_comboBox, &QComboBox::editTextChanged, [=](const QString &){emit this->entryChanged();});
 
         if (editDimension)
         {
@@ -37,8 +37,8 @@ public:
             _spinBox->setPrefix("x");
             _spinBox->setMinimum(1);
             _spinBox->setMaximum(std::numeric_limits<short>::max()); //numeric maximum affects line edit width
-            connect(_spinBox, SIGNAL(editingFinished(void)), this, SIGNAL(widgetChanged(void)));
-            connect(_spinBox, SIGNAL(valueChanged(const QString &)), this, SLOT(handleWidgetChanged(const QString &)));
+            connect(_spinBox, &QSpinBox::editingFinished, [=](void){emit this->widgetChanged();});
+            connect(_spinBox, QOverload<int>::of(&QSpinBox::valueChanged), [=](int){emit this->entryChanged();});
         }
 
         _comboBox->setObjectName("BlockPropertiesEditWidget"); //to pick up eval color style
@@ -102,16 +102,6 @@ signals:
     void commitRequested(void);
     void widgetChanged(void);
     void entryChanged(void);
-
-private slots:
-    void handleWidgetChanged(const QString &)
-    {
-        emit this->widgetChanged();
-    }
-    void handleEntryChanged(const QString &)
-    {
-        emit this->entryChanged();
-    }
 
 private:
     static QString unQuote(const QString &s)

--- a/EditWidgets/DoubleSpinBox.cpp
+++ b/EditWidgets/DoubleSpinBox.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Plugin.hpp>
@@ -17,8 +17,8 @@ public:
     DoubleSpinBox(QWidget *parent):
         QDoubleSpinBox(parent)
     {
-        connect(this, SIGNAL(editingFinished(void)), this, SIGNAL(widgetChanged(void)));
-        connect(this, SIGNAL(valueChanged(const QString &)), this, SLOT(handleWidgetChanged(const QString &)));
+        connect(this, &QDoubleSpinBox::editingFinished, this, &DoubleSpinBox::widgetChanged);
+        connect(this, QOverload<double>::of(&QDoubleSpinBox::valueChanged), [=](double){this->handleWidgetChanged();});
     }
 
 public slots:
@@ -39,7 +39,7 @@ signals:
     void entryChanged(void);
 
 private slots:
-    void handleWidgetChanged(const QString &)
+    void handleWidgetChanged(void)
     {
         //extract value as a string, in C locale format, preserving decimal points
         //this allows the QDoubleSpinBox to support the user's locale setting

--- a/EditWidgets/FileEntry.cpp
+++ b/EditWidgets/FileEntry.cpp
@@ -28,7 +28,7 @@ public:
         layout->addWidget(_edit, 1);
         layout->addWidget(_button, 0, Qt::AlignRight);
         _button->setMaximumWidth(20);
-        connect(_button, SIGNAL(pressed(void)), this, SLOT(handlePressed(void)));
+        connect(_button, &QPushButton::pressed, this, &FileEntry::handlePressed);
         connect(_edit, SIGNAL(textEdited(const QString &)), this, SLOT(handleTextEdited(const QString &)));
         connect(_edit, SIGNAL(returnPressed(void)), this, SIGNAL(commitRequested(void)));
         _edit->setObjectName("BlockPropertiesEditWidget"); //to pick up eval color style

--- a/EditWidgets/FileEntry.cpp
+++ b/EditWidgets/FileEntry.cpp
@@ -29,8 +29,8 @@ public:
         layout->addWidget(_button, 0, Qt::AlignRight);
         _button->setMaximumWidth(20);
         connect(_button, &QPushButton::pressed, this, &FileEntry::handlePressed);
-        connect(_edit, SIGNAL(textEdited(const QString &)), this, SLOT(handleTextEdited(const QString &)));
-        connect(_edit, SIGNAL(returnPressed(void)), this, SIGNAL(commitRequested(void)));
+        connect(_edit, &QLineEdit::textEdited, [=](const QString &){emit this->entryChanged();});
+        connect(_edit, &QLineEdit::returnPressed, this, &FileEntry::commitRequested);
         _edit->setObjectName("BlockPropertiesEditWidget"); //to pick up eval color style
     }
 
@@ -66,11 +66,6 @@ private slots:
         if (filePath.isEmpty()) return;
         this->setValue(filePath);
         emit this->widgetChanged();
-    }
-
-    void handleTextEdited(const QString &)
-    {
-        emit this->entryChanged();
     }
 
 private:

--- a/EditWidgets/LineEdit.cpp
+++ b/EditWidgets/LineEdit.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Plugin.hpp>
@@ -16,8 +16,8 @@ public:
     LineEdit(QWidget *parent):
         QLineEdit(parent)
     {
-        connect(this, SIGNAL(textEdited(const QString &)), this, SLOT(handleTextEdited(const QString &)));
-        connect(this, SIGNAL(returnPressed(void)), this, SIGNAL(commitRequested(void)));
+        connect(this, &QLineEdit::textEdited, [=](const QString &){emit this->entryChanged();});
+        connect(this, &QLineEdit::returnPressed, this, &LineEdit::commitRequested);
     }
 
 public slots:
@@ -35,12 +35,6 @@ signals:
     void commitRequested(void);
     void widgetChanged(void);
     void entryChanged(void);
-
-private slots:
-    void handleTextEdited(const QString &)
-    {
-        emit this->entryChanged();
-    }
 };
 
 /***********************************************************************

--- a/EditWidgets/SpinBox.cpp
+++ b/EditWidgets/SpinBox.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Plugin.hpp>
@@ -17,8 +17,8 @@ public:
     SpinBox(QWidget *parent):
         QSpinBox(parent)
     {
-        connect(this, SIGNAL(editingFinished(void)), this, SIGNAL(widgetChanged(void)));
-        connect(this, SIGNAL(valueChanged(const QString &)), this, SLOT(handleWidgetChanged(const QString &)));
+        connect(this, &SpinBox::editingFinished, this, &SpinBox::widgetChanged);
+        connect(this, QOverload<int>::of(&SpinBox::valueChanged), [=](int){this->handleWidgetChanged();});
     }
 
 public slots:
@@ -39,7 +39,7 @@ signals:
     void entryChanged(void);
 
 private slots:
-    void handleWidgetChanged(const QString &)
+    void handleWidgetChanged(void)
     {
         _value = QSpinBox::text();
         emit this->widgetChanged();

--- a/EditWidgets/StringEntry.cpp
+++ b/EditWidgets/StringEntry.cpp
@@ -16,8 +16,8 @@ public:
     StringEntry(QWidget *parent):
         QLineEdit(parent)
     {
-        connect(this, SIGNAL(textEdited(const QString &)), this, SLOT(handleTextEdited(const QString &)));
-        connect(this, SIGNAL(returnPressed(void)), this, SIGNAL(commitRequested(void)));
+        connect(this, &QLineEdit::textEdited, [=](const QString &){emit this->entryChanged();});
+        connect(this, &QLineEdit::returnPressed, this, &StringEntry::commitRequested);
     }
 
 public slots:
@@ -41,12 +41,6 @@ signals:
     void commitRequested(void);
     void widgetChanged(void);
     void entryChanged(void);
-
-private slots:
-    void handleTextEdited(const QString &)
-    {
-        emit this->entryChanged();
-    }
 };
 
 /***********************************************************************

--- a/EditWidgets/ToggleButton.cpp
+++ b/EditWidgets/ToggleButton.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2017 Josh Blum
+// Copyright (c) 2017-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include <Pothos/Plugin.hpp>
@@ -19,7 +19,7 @@ public:
         _offText(offText)
     {
         this->setCheckable(true);
-        connect(this, SIGNAL(toggled(bool)), this, SLOT(handleToggled(bool)));
+        connect(this, &QPushButton::toggled, this, &ToggleButton::handleToggled);
     }
 
 public slots:

--- a/EditWidgets/ToggleSwitch.cpp
+++ b/EditWidgets/ToggleSwitch.cpp
@@ -35,7 +35,7 @@ public:
         this->setCheckable(true);
         this->setFocusPolicy(Qt::StrongFocus);
         this->setCursor(Qt::PointingHandCursor);
-        connect(this, SIGNAL(toggled(bool)), this, SLOT(handleToggled(bool)));
+        connect(this, &QAbstractButton::toggled, this, &ToggleSwitch::handleToggled);
     }
 
     int offset(void) const

--- a/EvalEngine/EvalEngine.hpp
+++ b/EvalEngine/EvalEngine.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -12,7 +12,6 @@ class QThread;
 class QTimer;
 class EvalEngineImpl;
 class AffinityZonesDock;
-class QSignalMapper;
 class EvalTracer;
 
 /*!
@@ -28,6 +27,9 @@ public:
     EvalEngine(QObject *parent);
 
     ~EvalEngine(void);
+
+signals:
+    void deactivateDesign(void);
 
 public slots:
 
@@ -76,7 +78,6 @@ private:
     QThread *_thread;
     QTimer *_monitorTimer;
     EvalEngineImpl *_impl;
-    QSignalMapper *_blockEvalMapper;
     AffinityZonesDock *_affinityDock;
     std::chrono::system_clock::time_point _lastHeartBeat;
 };

--- a/GraphEditor/DockingTabWidget.cpp
+++ b/GraphEditor/DockingTabWidget.cpp
@@ -3,7 +3,6 @@
 
 #include "DockingTabWidget.hpp"
 #include "MainWindow/IconUtils.hpp"
-#include <QSignalMapper>
 #include <QPushButton>
 #include <QTabBar>
 #include <QIcon>
@@ -16,7 +15,6 @@
 #include <QApplication>
 #include "MainWindow/MainActions.hpp"
 #include "MainWindow/MainWindow.hpp"
-#include <iostream>
 
 /***********************************************************************
  * The docking page holds the actual internal tab page widget
@@ -176,11 +174,9 @@ private:
  * Docking tab widget implementation
  **********************************************************************/
 DockingTabWidget::DockingTabWidget(QWidget *parent):
-    QTabWidget(parent),
-    _mapper(new QSignalMapper(this))
+    QTabWidget(parent)
 {
     MainWindow::global()->installEventFilter(this);
-    this->connect(_mapper, SIGNAL(mapped(QWidget *)), this, SLOT(handleUndockButton(QWidget *)));
 }
 
 DockingTabWidget::~DockingTabWidget(void)
@@ -363,8 +359,7 @@ void DockingTabWidget::tabInserted(int index)
         QString("QPushButton:checked:hover{border-image: url(%1);}").arg(makeIconPath("dockingtab-undock-hover.png"))+
         QString("QPushButton:checked:pressed{border-image: url(%1);}").arg(makeIconPath("dockingtab-undock-down.png"));
     button->setStyleSheet(buttonStyle);
-    _mapper->setMapping(button, QTabWidget::widget(index));
-    connect(button, SIGNAL(clicked()), _mapper, SLOT(map()));
+    connect(button, &QPushButton::clicked, [=](void){this->handleUndockButton(QTabWidget::widget(index));});
     this->tabBar()->setTabButton(index, QTabBar::RightSide, button);
     this->page(index)->internalUpdate();
 

--- a/GraphEditor/DockingTabWidget.hpp
+++ b/GraphEditor/DockingTabWidget.hpp
@@ -1,11 +1,9 @@
-// Copyright (c) 2018-2018 Josh Blum
+// Copyright (c) 2018-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
 #include <Pothos/Config.hpp>
 #include <QTabWidget>
-
-class QSignalMapper;
 
 /*!
  * A customized tab widget with detachable tabs that can become independent windows.
@@ -81,18 +79,15 @@ signals:
     //! Called when active window changes (dialog vs main window focus)
     void activeChanged(void);
 
-private slots:
-    void handleUndockButton(QWidget *);
-
 protected:
     void tabInserted(int index);
     void tabRemoved(int index);
     bool eventFilter(QObject *object, QEvent *event);
 
 private:
+    void handleUndockButton(QWidget *);
     class DockingPage;
     DockingPage *page(const int index) const;
     void internalUpdate(void);
-    QSignalMapper *_mapper;
     QString _dialogTitle;
 };

--- a/GraphEditor/GraphDraw.cpp
+++ b/GraphEditor/GraphDraw.cpp
@@ -60,7 +60,7 @@ GraphDraw::GraphDraw(QWidget *parent):
         this, SLOT(handleCustomContextMenuRequested(const QPoint &)));
     connect(this, SIGNAL(modifyProperties(QObject *)),
         PropertiesPanelDock::global(), SLOT(launchEditor(QObject *)));
-    connect(this->scene(), SIGNAL(selectionChanged(void)), this, SLOT(updateEnabledActions(void)));
+    connect(this->scene(), &QGraphicsScene::selectionChanged, this, &GraphDraw::updateEnabledActions);
 
     //debug view - connect and initialize
     auto actions = MainActions::global();

--- a/GraphEditor/GraphEditor.hpp
+++ b/GraphEditor/GraphEditor.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2019 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -12,7 +12,6 @@
 
 class GraphConnection;
 class GraphDraw;
-class QSignalMapper;
 class QTabWidget;
 class EvalEngine;
 class QTimer;
@@ -150,7 +149,7 @@ private slots:
     void handleRenameGraphPage(void);
     void handleDeleteGraphPage(void);
     void handleMoveGraphObjects(const int index);
-    void handleAddBlock(const QJsonObject &);
+    void handleAddBlockSlot(const QJsonObject &);
     void handleCreateBreaker(const bool isInput);
     void handleCreateInputBreaker(void);
     void handleCreateOutputBreaker(void);
@@ -198,9 +197,6 @@ private:
     void makeDefaultPage(void);
 
     void deleteFlagged(void);
-
-    QSignalMapper *_moveGraphObjectsMapper;
-    QSignalMapper *_insertGraphWidgetsMapper;
 
     QString _currentFilePath;
     QPointer<GraphStateManager> _stateManager;

--- a/GraphEditor/GraphEditorRenderedDialog.cpp
+++ b/GraphEditor/GraphEditorRenderedDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2019 Josh Blum
+// Copyright (c) 2013-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "GraphEditor/GraphEditor.hpp"
@@ -53,9 +53,9 @@ public:
         portOptionsLayout->addRow(tr("Show ports"), _portOptions);
 
         //connect widget changed events
-        connect(_modeOptions, SIGNAL(currentIndexChanged(int)), this, SLOT(handleChange(int)));
-        connect(_portOptions, SIGNAL(currentIndexChanged(int)), this, SLOT(handleChange(int)));
-        connect(_process, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(handleProcessDone(int, QProcess::ExitStatus)));
+        connect(_modeOptions, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &RenderedGraphDialog::handleChange);
+        connect(_portOptions, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &RenderedGraphDialog::handleChange);
+        connect(_process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &RenderedGraphDialog::handleProcessDone);
         connect(_graphEditor, &GraphEditor::windowTitleUpdated, this, &RenderedGraphDialog::handleWindowTitleUpdated);
 
         //initialize

--- a/GraphEditor/GraphEditorTabs.cpp
+++ b/GraphEditor/GraphEditorTabs.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2018 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "MainWindow/IconUtils.hpp"
@@ -32,17 +32,17 @@ GraphEditorTabs::GraphEditorTabs(QWidget *parent):
         QString("QTabBar::close-button:pressed {image: url(%1);}").arg(makeIconPath("standardbutton-closetab-down-16.png")));
 
     auto actions = MainActions::global();
-    connect(actions->newAction, SIGNAL(triggered(void)), this, SLOT(handleNew(void)));
-    connect(actions->openAction, SIGNAL(triggered(void)), this, SLOT(handleOpen(void)));
-    connect(actions->saveAction, SIGNAL(triggered(void)), this, SLOT(handleSave(void)));
-    connect(actions->saveAsAction, SIGNAL(triggered(void)), this, SLOT(handleSaveAs(void)));
-    connect(actions->saveAllAction, SIGNAL(triggered(void)), this, SLOT(handleSaveAll(void)));
-    connect(actions->reloadAction, SIGNAL(triggered(void)), this, SLOT(handleReload(void)));
-    connect(actions->closeAction, SIGNAL(triggered(void)), this, SLOT(handleClose(void)));
-    connect(actions->exportAction, SIGNAL(triggered(void)), this, SLOT(handleExport(void)));
-    connect(actions->exportAsAction, SIGNAL(triggered(void)), this, SLOT(handleExportAs(void)));
-    connect(this, SIGNAL(tabCloseRequested(int)), this, SLOT(handleClose(int)));
-    connect(this->tabBar(), SIGNAL(tabMoved(int, int)), this, SLOT(handleTabMoved(int, int)));
+    connect(actions->newAction, &QAction::triggered, [=](void){this->handleNew();});
+    connect(actions->openAction, &QAction::triggered, [=](void){this->handleOpen();});
+    connect(actions->saveAction, &QAction::triggered, [=](void){this->handleSave();});
+    connect(actions->saveAsAction, &QAction::triggered, [=](void){this->handleSaveAs();});
+    connect(actions->saveAllAction, &QAction::triggered, [=](void){this->handleSaveAll();});
+    connect(actions->reloadAction, &QAction::triggered, [=](void){this->handleReload();});
+    connect(actions->closeAction, &QAction::triggered, [=](void){this->handleClose();});
+    connect(actions->exportAction, &QAction::triggered, [=](void){this->handleExport();});
+    connect(actions->exportAsAction, &QAction::triggered, [=](void){this->handleExportAs();});
+    connect(this, &GraphEditorTabs::tabCloseRequested, [=](int i){this->handleCloseIndex(i);});
+    connect(this->tabBar(), &QTabBar::tabMoved, [=](int, int){this->saveState();});
 }
 
 GraphEditor *GraphEditorTabs::getGraphEditor(const int i) const
@@ -192,7 +192,7 @@ void GraphEditorTabs::handleClose(void)
     this->handleClose(editor);
 }
 
-void GraphEditorTabs::handleClose(int index)
+void GraphEditorTabs::handleCloseIndex(int index)
 {
     auto editor = qobject_cast<GraphEditor *>(this->widget(index));
     assert(editor != nullptr);
@@ -221,7 +221,7 @@ void GraphEditorTabs::handleClose(GraphEditor *editor)
 void GraphEditorTabs::handleExit(QCloseEvent *event)
 {
     //dont save state for any further tab selection changes
-    disconnect(this, SIGNAL(currentChanged(int)), this, SLOT(handleChanged(int)));
+    disconnect(this, &GraphEditorTabs::currentChanged, this, &GraphEditorTabs::handleChanged);
 
     //exit logic -- save changes dialogs
     for (int i = 0; i < this->count(); i++)
@@ -284,11 +284,6 @@ void GraphEditorTabs::handleExportAs(void)
 }
 
 void GraphEditorTabs::handleChanged(int)
-{
-    this->saveState();
-}
-
-void GraphEditorTabs::handleTabMoved(int, int)
 {
     this->saveState();
 }

--- a/GraphEditor/GraphEditorTabs.hpp
+++ b/GraphEditor/GraphEditorTabs.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -32,12 +32,11 @@ private slots:
     void handleSaveAll(void);
     void handleReload(void);
     void handleClose(void);
-    void handleClose(int);
+    void handleCloseIndex(int);
     void handleClose(GraphEditor *editor);
     void handleExport(void);
     void handleExportAs(void);
     void handleChanged(int);
-    void handleTabMoved(int, int);
 
 private:
     void doReloadDialog(GraphEditor *editor);

--- a/GraphObjects/GraphConnection.cpp
+++ b/GraphObjects/GraphConnection.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2018 Josh Blum
+// Copyright (c) 2013-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "GraphObjects/GraphConnection.hpp"
@@ -73,13 +73,13 @@ void GraphConnection::setupEndpoint(const GraphConnectionEndpoint &ep)
     }
 
     //connected deleted signal so the connection deletes with the endpoint's parent object
-    connect(ep.getObj(), SIGNAL(destroyed(QObject *)), this, SLOT(handleEndPointDestroyed(QObject *)));
+    connect(ep.getObj(), &GraphObject::destroyed, this, &GraphConnection::handleEndPointDestroyed);
 
     //connect eval signal to check if the endpoint exists and delete this connection
     auto graphBlock = qobject_cast<GraphBlock *>(ep.getObj().data());
     if (graphBlock != nullptr)
     {
-        connect(ep.getObj(), SIGNAL(evalDoneEvent(void)), this, SLOT(handleEndPointEventRecheck(void)));
+        connect(graphBlock, &GraphBlock::evalDoneEvent, this, &GraphConnection::handleEndPointEventRecheck);
         graphBlock->registerEndpoint(ep);
     }
 

--- a/GraphObjects/GraphWidget.cpp
+++ b/GraphObjects/GraphWidget.cpp
@@ -52,7 +52,7 @@ GraphWidget::GraphWidget(QObject *parent):
     _impl(new Impl(this))
 {
     this->setFlag(QGraphicsItem::ItemIsMovable);
-    connect(_impl->container, SIGNAL(resized(void)), this, SLOT(handleWidgetResized(void)));
+    connect(_impl->container, &GraphWidgetContainer::resized, this, &GraphWidget::handleWidgetResized);
     connect(this, SIGNAL(lockedChanged(bool)), _impl->container, SLOT(handleLockedChanged(bool)));
 }
 
@@ -70,7 +70,7 @@ void GraphWidget::setGraphBlock(GraphBlock *block)
     _impl->block = block;
     connect(block, SIGNAL(destroyed(QObject *)), this, SLOT(handleBlockDestroyed(QObject *)));
     connect(block, SIGNAL(IDChanged(const QString &)), this, SLOT(handleBlockIdChanged(const QString &)));
-    connect(block, SIGNAL(evalDoneEvent(void)), this, SLOT(handleBlockEvalDone(void)));
+    connect(block, &GraphBlock::evalDoneEvent, this, &GraphWidget::handleBlockEvalDone);
     this->handleBlockIdChanged(block->getId()); //init value
 }
 

--- a/GraphObjects/GraphWidget.cpp
+++ b/GraphObjects/GraphWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2018 Josh Blum
+// Copyright (c) 2013-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "GraphObjects/GraphWidget.hpp"
@@ -53,7 +53,7 @@ GraphWidget::GraphWidget(QObject *parent):
 {
     this->setFlag(QGraphicsItem::ItemIsMovable);
     connect(_impl->container, &GraphWidgetContainer::resized, this, &GraphWidget::handleWidgetResized);
-    connect(this, SIGNAL(lockedChanged(bool)), _impl->container, SLOT(handleLockedChanged(bool)));
+    connect(this, &GraphWidget::lockedChanged, _impl->container, &GraphWidgetContainer::handleLockedChanged);
 }
 
 GraphWidget::~GraphWidget(void)
@@ -68,8 +68,8 @@ void GraphWidget::setGraphBlock(GraphBlock *block)
     assert(not _impl->block);
 
     _impl->block = block;
-    connect(block, SIGNAL(destroyed(QObject *)), this, SLOT(handleBlockDestroyed(QObject *)));
-    connect(block, SIGNAL(IDChanged(const QString &)), this, SLOT(handleBlockIdChanged(const QString &)));
+    connect(block, &GraphBlock::destroyed, this, &GraphWidget::handleBlockDestroyed);
+    connect(block, &GraphBlock::IDChanged, this, &GraphWidget::handleBlockIdChanged);
     connect(block, &GraphBlock::evalDoneEvent, this, &GraphWidget::handleBlockEvalDone);
     this->handleBlockIdChanged(block->getId()); //init value
 }

--- a/GraphObjects/GraphWidgetContainer.hpp
+++ b/GraphObjects/GraphWidgetContainer.hpp
@@ -42,14 +42,14 @@ signals:
     //! emit when the resize operation completes
     void resized(void);
 
+public slots:
+    void handleLockedChanged(const bool locked);
+
 protected:
     void enterEvent(QEnterEventCompat *event) override;
     void leaveEvent(QEvent *event) override;
     void updateShowGrip(void);
     void paintEvent(QPaintEvent *event) override;
-
-private slots:
-    void handleLockedChanged(const bool locked);
 
 private:
     QStaticText _gripLabel;

--- a/HostExplorer/HostExplorerDock.hpp
+++ b/HostExplorer/HostExplorerDock.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2013 Josh Blum
+// Copyright (c) 2013-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -7,7 +7,6 @@
 #include <QStringList>
 
 class HostSelectionTable;
-class QSignalMapper;
 class QTabWidget;
 
 //! top level dock widget for dealing with hosts
@@ -33,6 +32,7 @@ private slots:
 private:
     HostSelectionTable *_table;
     QTabWidget *_tabs;
-    QSignalMapper *_startMapper;
-    QSignalMapper *_stopMapper;
+
+    template <typename T>
+    void addTabAndConnect(T *tabWidget, const QString &name);
 };

--- a/HostExplorer/HostSelectionTable.hpp
+++ b/HostExplorer/HostSelectionTable.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2017 Josh Blum
+// Copyright (c) 2013-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -12,7 +12,6 @@
 
 class HostUriQLineEdit;
 class QToolButton;
-class QSignalMapper;
 class QTimer;
 
 //! information stored about a node
@@ -55,8 +54,6 @@ private slots:
 
     void handleAdd(const QString &uri);
 
-    void handleNodeQueryComplete(void);
-
     void handleUpdateStatus(void);
 
 private:
@@ -68,9 +65,9 @@ private:
     void showErrorMessage(const QString &errMsg);
     HostUriQLineEdit *_lineEdit;
     QToolButton *_addButton;
-    QSignalMapper *_removeMapper;
     QTimer *_timer;
-    QFutureWatcher<std::vector<NodeInfo>> *_watcher;
+    typedef QFutureWatcher<std::vector<NodeInfo>> FutureWatcherT;
+    FutureWatcherT *_watcher;
     std::map<QString, size_t> _uriToRow;
     std::map<QString, NodeInfo> _uriToInfo;
     static const size_t nCols = 4;

--- a/HostExplorer/PluginModuleTree.cpp
+++ b/HostExplorer/PluginModuleTree.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2018 Josh Blum
+// Copyright (c) 2013-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "HostExplorer/PluginModuleTree.hpp"
@@ -77,7 +77,7 @@ PluginModuleTree::PluginModuleTree(QWidget *parent):
         this, SLOT(handleWatcherDone(void)));
 }
 
-void PluginModuleTree::handeInfoRequest(const std::string &uriStr)
+void PluginModuleTree::handleInfoRequest(const std::string &uriStr)
 {
     if (_watcher->isRunning()) return;
     while (this->topLevelItemCount() > 0) delete this->topLevelItem(0);

--- a/HostExplorer/PluginModuleTree.hpp
+++ b/HostExplorer/PluginModuleTree.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2018 Josh Blum
+// Copyright (c) 2013-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -27,7 +27,7 @@ signals:
     void stopLoad(void);
 
 public slots:
-    void handeInfoRequest(const std::string &uriStr);
+    void handleInfoRequest(const std::string &uriStr);
 
 private slots:
 

--- a/HostExplorer/PluginRegistryTree.cpp
+++ b/HostExplorer/PluginRegistryTree.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2017 Josh Blum
+// Copyright (c) 2013-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "HostExplorer/PluginRegistryTree.hpp"
@@ -83,7 +83,7 @@ PluginRegistryTree::PluginRegistryTree(QWidget *parent):
         this, SLOT(handleWatcherDone(void)));
 }
 
-void PluginRegistryTree::handeInfoRequest(const std::string &uriStr)
+void PluginRegistryTree::handleInfoRequest(const std::string &uriStr)
 {
     if (_watcher->isRunning()) return;
     while (this->topLevelItemCount() > 0) delete this->topLevelItem(0);

--- a/HostExplorer/PluginRegistryTree.hpp
+++ b/HostExplorer/PluginRegistryTree.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 Josh Blum
+// Copyright (c) 2013-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -20,7 +20,7 @@ signals:
     void stopLoad(void);
 
 public slots:
-    void handeInfoRequest(const std::string &uriStr);
+    void handleInfoRequest(const std::string &uriStr);
 
 private slots:
 

--- a/HostExplorer/SystemInfoTree.cpp
+++ b/HostExplorer/SystemInfoTree.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2017 Josh Blum
+// Copyright (c) 2013-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "HostExplorer/SystemInfoTree.hpp"
@@ -60,7 +60,7 @@ SystemInfoTree::SystemInfoTree(QWidget *parent):
         this, SLOT(handleWatcherDone(void)));
 }
 
-void SystemInfoTree::handeInfoRequest(const std::string &uriStr)
+void SystemInfoTree::handleInfoRequest(const std::string &uriStr)
 {
     if (_watcher->isRunning()) return;
     while (this->topLevelItemCount() > 0) delete this->topLevelItem(0);

--- a/HostExplorer/SystemInfoTree.hpp
+++ b/HostExplorer/SystemInfoTree.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2018 Josh Blum
+// Copyright (c) 2013-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -31,7 +31,7 @@ signals:
     void stopLoad(void);
 
 public slots:
-    void handeInfoRequest(const std::string &uriStr);
+    void handleInfoRequest(const std::string &uriStr);
 
 private slots:
 

--- a/MainWindow/MainWindow.cpp
+++ b/MainWindow/MainWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2018 Josh Blum
+// Copyright (c) 2013-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #include "MainWindow/MainWindow.hpp"
@@ -69,8 +69,8 @@ MainWindow::MainWindow(QWidget *parent):
     connect(_actions->showAboutAction, &QAction::triggered, this, &MainWindow::handleShowAbout);
     connect(_actions->showAboutQtAction, &QAction::triggered, this, &MainWindow::handleShowAboutQt);
     connect(_actions->showColorsDialogAction, &QAction::triggered, this, &MainWindow::handleColorsDialogAction);
-    connect(_actions->fullScreenViewAction, SIGNAL(toggled(bool)), this, SLOT(handleFullScreenViewAction(bool)));
-    connect(_actions->reloadPluginsAction, SIGNAL(triggered(bool)), this, SLOT(handleReloadPlugins(void)));
+    connect(_actions->fullScreenViewAction, &QAction::toggled, this, &MainWindow::handleFullScreenViewAction);
+    connect(_actions->reloadPluginsAction, &QAction::triggered, this, &MainWindow::handleReloadPlugins);
 
     //create message window dock
     _splash->postMessage(tr("Creating message window..."));

--- a/MainWindow/MainWindow.cpp
+++ b/MainWindow/MainWindow.cpp
@@ -65,10 +65,10 @@ MainWindow::MainWindow(QWidget *parent):
     auto mainMenu = new MainMenu(this, _actions);
 
     //connect actions to the main window
-    connect(_actions->exitAction, SIGNAL(triggered(void)), this, SLOT(close(void)));
-    connect(_actions->showAboutAction, SIGNAL(triggered(void)), this, SLOT(handleShowAbout(void)));
-    connect(_actions->showAboutQtAction, SIGNAL(triggered(void)), this, SLOT(handleShowAboutQt(void)));
-    connect(_actions->showColorsDialogAction, SIGNAL(triggered(void)), this, SLOT(handleColorsDialogAction(void)));
+    connect(_actions->exitAction, &QAction::triggered, this, &MainWindow::close);
+    connect(_actions->showAboutAction, &QAction::triggered, this, &MainWindow::handleShowAbout);
+    connect(_actions->showAboutQtAction, &QAction::triggered, this, &MainWindow::handleShowAboutQt);
+    connect(_actions->showColorsDialogAction, &QAction::triggered, this, &MainWindow::handleColorsDialogAction);
     connect(_actions->fullScreenViewAction, SIGNAL(toggled(bool)), this, SLOT(handleFullScreenViewAction(bool)));
     connect(_actions->reloadPluginsAction, SIGNAL(triggered(bool)), this, SLOT(handleReloadPlugins(void)));
 
@@ -111,7 +111,7 @@ MainWindow::MainWindow(QWidget *parent):
     //create block tree (after the block cache)
     _splash->postMessage(tr("Creating block tree..."));
     auto blockTreeDock = new BlockTreeDock(this, _blockCache, _editorTabs);
-    connect(_actions->findAction, SIGNAL(triggered(void)), blockTreeDock, SLOT(activateFind(void)));
+    connect(_actions->findAction, &QAction::triggered, blockTreeDock, &BlockTreeDock::activateFind);
     this->tabifyDockWidget(affinityZonesDock, blockTreeDock);
 
     //create properties panel (make after block cache)

--- a/MessageWindow/LoggerDisplay.cpp
+++ b/MessageWindow/LoggerDisplay.cpp
@@ -10,7 +10,6 @@
 #include <QToolButton>
 #include <QTimer>
 #include <Poco/DateTimeFormatter.h>
-#include <iostream>
 
 static const long CHECK_MSGS_TIMEOUT_MS = 100;
 static const size_t MAX_MSGS_PER_TIMEOUT = 3;
@@ -31,8 +30,7 @@ LoggerDisplay::LoggerDisplay(QWidget *parent):
     _clearButton->hide();
     _clearButton->setIcon(makeIconFromTheme("edit-clear-list"));
     _clearButton->setToolTip(tr("Clear message history"));
-    connect(_clearButton, SIGNAL(clicked(void)), _text, SLOT(clear(void)));
-
+    connect(_clearButton, &QToolButton::clicked, _text, &QPlainTextEdit::clear);
     connect(_timer, &QTimer::timeout, this, &LoggerDisplay::handleCheckMsgs);
     _timer->start(CHECK_MSGS_TIMEOUT_MS);
 }

--- a/PropertiesPanel/BlockPropertiesPanel.cpp
+++ b/PropertiesPanel/BlockPropertiesPanel.cpp
@@ -111,7 +111,7 @@ BlockPropertiesPanel::BlockPropertiesPanel(GraphBlock *block, QWidget *parent):
         _affinityZoneOriginal = _block->getAffinityZone();
         _affinityZoneBox = AffinityZonesDock::global()->makeComboBox(this);
         _formLayout->addRow(_affinityZoneLabel, _affinityZoneBox);
-        connect(_affinityZoneBox, SIGNAL(activated(const QString &)), this, SLOT(handleAffinityZoneChanged(const QString &)));
+        connect(_affinityZoneBox, QOverload<int>::of(&QComboBox::activated), [=](int){emit this->handleAffinityZoneChanged();});
     }
 
     //errors
@@ -272,7 +272,7 @@ void BlockPropertiesPanel::handleWidgetChanged(void)
     this->updateAllForms(); //quick update for labels
 }
 
-void BlockPropertiesPanel::handleAffinityZoneChanged(const QString &)
+void BlockPropertiesPanel::handleAffinityZoneChanged(void)
 {
     this->handleWidgetChanged();
     emit _block->triggerEvalEvent();

--- a/PropertiesPanel/BlockPropertiesPanel.cpp
+++ b/PropertiesPanel/BlockPropertiesPanel.cpp
@@ -94,10 +94,10 @@ BlockPropertiesPanel::BlockPropertiesPanel(GraphBlock *block, QWidget *parent):
 
         //create editable widget
         auto editWidget = new PropertyEditWidget(_block->getPropertyValue(propKey), paramDesc, editMode, this);
-        connect(editWidget, SIGNAL(widgetChanged(void)), this, SLOT(handleWidgetChanged(void)));
+        connect(editWidget, &PropertyEditWidget::widgetChanged, this, &BlockPropertiesPanel::handleWidgetChanged);
         connect(editWidget, SIGNAL(widgetChanged(void)), _block, SIGNAL(triggerEvalEvent(void)));
-        connect(editWidget, SIGNAL(entryChanged(void)), this, SLOT(handleWidgetChanged(void)));
-        connect(editWidget, SIGNAL(commitRequested(void)), this, SLOT(handleCommit(void)));
+        connect(editWidget, &PropertyEditWidget::entryChanged, this, &BlockPropertiesPanel::handleWidgetChanged);
+        connect(editWidget, &PropertyEditWidget::commitRequested, this, &BlockPropertiesPanel::handleCommit);
         _propIdToEditWidget[propKey] = editWidget;
         editWidget->setToolTip(this->getParamDocString(propKey));
 

--- a/PropertiesPanel/BlockPropertiesPanel.hpp
+++ b/PropertiesPanel/BlockPropertiesPanel.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -37,7 +37,7 @@ private slots:
     //! Handle for all widget change events
     void handleWidgetChanged(void);
 
-    void handleAffinityZoneChanged(const QString &);
+    void handleAffinityZoneChanged(void);
 
     void handleBlockEvalDone(void);
 

--- a/PropertiesPanel/GraphPropertiesPanel.cpp
+++ b/PropertiesPanel/GraphPropertiesPanel.cpp
@@ -84,11 +84,11 @@ GraphPropertiesPanel::GraphPropertiesPanel(GraphEditor *editor, QWidget *parent)
         _varsMoveDownButton->setToolTip(tr("Move selected global variable down"));
 
         //connect signals
-        connect(_varsAddButton, SIGNAL(clicked(void)), this, SLOT(handleCreateVariable(void)));
-        connect(_varNameEntry, &QLineEdit::returnPressed, this, &GraphPropertiesPanel::handleCreateVariable);
-        connect(_varsRemoveButton, SIGNAL(clicked(void)), this, SLOT(handleVariableRemoval(void)));
-        connect(_varsMoveUpButton, SIGNAL(clicked(void)), this, SLOT(handleVariableMoveUp(void)));
-        connect(_varsMoveDownButton, SIGNAL(clicked(void)), this, SLOT(handleVariableMoveDown(void)));
+        connect(_varsAddButton, &QToolButton::clicked, [=](void){this->handleCreateVariable();});
+        connect(_varNameEntry, &QLineEdit::returnPressed, [=](void){this->handleCreateVariable();});
+        connect(_varsRemoveButton, &QToolButton::clicked, [=](void){this->handleVariableRemoval();});
+        connect(_varsMoveUpButton, &QToolButton::clicked, [=](void){this->handleVariableMoveUp();});
+        connect(_varsMoveDownButton, &QToolButton::clicked, [=](void){this->handleVariableMoveDown();});
     }
 
     //graph config

--- a/PropertiesPanel/GraphPropertiesPanel.cpp
+++ b/PropertiesPanel/GraphPropertiesPanel.cpp
@@ -398,7 +398,7 @@ void GraphPropertiesPanel::createVariableEditWidget(const QString &name)
 
     //selection button
     auto radioButton = new QRadioButton(this);
-    connect(radioButton, SIGNAL(clicked(void)), this, SLOT(updateAllVariableForms(void)));
+    connect(radioButton, &QRadioButton::clicked, this, &GraphPropertiesPanel::updateAllVariableForms);
     editLayout->addWidget(radioButton);
     _varsSelectionGroup->addButton(radioButton);
 

--- a/PropertiesPanel/PropertiesPanelDock.hpp
+++ b/PropertiesPanel/PropertiesPanelDock.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2016 Josh Blum
+// Copyright (c) 2014-2021 Josh Blum
 // SPDX-License-Identifier: BSL-1.0
 
 #pragma once
@@ -8,6 +8,7 @@
 
 class QScrollArea;
 class QPushButton;
+class GraphEditor;
 
 class PropertiesPanelDock : public QDockWidget
 {
@@ -34,6 +35,8 @@ private slots:
     void handleDeletePanel(void);
 
 private:
+    template <typename T>
+    void installNewPanel(T *panel, GraphEditor *editor);
     QPointer<QObject> _currentGraphObject;
     QPointer<QWidget> _propertiesPanel;
     QScrollArea *_scroll;

--- a/PropertiesPanel/PropertyEditWidget.cpp
+++ b/PropertiesPanel/PropertyEditWidget.cpp
@@ -45,7 +45,7 @@ PropertyEditWidget::PropertyEditWidget(const QString &initialValue, const QJsonO
     _modeButton->setFixedSize(QSize(20, 20));
     //focus color is distracting, dont enable focus
     _modeButton->setFocusPolicy(Qt::NoFocus);
-    connect(_modeButton, SIGNAL(clicked(void)), this, SLOT(handleModeButtonClicked(void)));
+    connect(_modeButton, &QToolButton::clicked, [=](void){this->handleModeButtonClicked();});
 
     //layout internal widgets
     _editLayout->setSpacing(0);
@@ -140,7 +140,7 @@ void PropertyEditWidget::reloadParamDesc(const QJsonObject &paramDesc_)
     //initialize value
     this->setValue(newValue);
 
-    //signals to internal handler
+    //signals to internal handler (opaque type, use runtime bindings for signals/slots)
     connect(_editWidget, SIGNAL(widgetChanged(void)), this, SLOT(handleWidgetChanged(void)));
     connect(_editWidget, SIGNAL(entryChanged(void)), this, SLOT(handleEntryChanged(void)));
     connect(_editWidget, SIGNAL(commitRequested(void)), this, SLOT(handleCommitRequested(void)));


### PR DESCRIPTION
Use newer connect() signatures with function pointers and lambdas where possible to get compile time checks. Qt6 has deleted many overloads for common widget signals. In addition, lambda clean up a lot of code where QSignalMapper was used